### PR TITLE
Fix DOC table rendering and streamline demo

### DIFF
--- a/apps/viewer-demo/src/components/HelloWorld.vue
+++ b/apps/viewer-demo/src/components/HelloWorld.vue
@@ -4,6 +4,7 @@ import {
   Check,
   ChevronDown,
   ChevronUp,
+  Code2,
   Copy,
   FileSearch,
   Link2,
@@ -129,6 +130,10 @@ const viewerSearchOpen = ref(false)
 const viewerSearchQuery = ref('')
 const viewerSearchInputRef = ref<HTMLInputElement | null>(null)
 const snippetCopied = ref(false)
+const snippetDialogOpen = ref(false)
+const snippetLaunchRef = ref<HTMLButtonElement | null>(null)
+const snippetCloseRef = ref<HTMLButtonElement | null>(null)
+const snippetDialogRef = ref<HTMLElement | null>(null)
 const viewerSearchState = ref<FileViewerSearchState>({
   query: '',
   total: 0,
@@ -240,6 +245,10 @@ const demoCopyMap: Record<DemoLocale, Record<string, string>> = {
     themeToLight: '切换为浅色模式',
     themeToDark: '切换为深色模式',
     integrationSnippet: '接入代码',
+    openIntegrationSnippet: '查看接入代码',
+    integrationSnippetHint: '在浮层中查看并复制示例',
+    integrationSnippetDescription: 'React 完整接入示例',
+    closeIntegrationSnippet: '关闭接入代码',
     copySnippet: '复制代码',
     copiedSnippet: '已复制'
   },
@@ -306,6 +315,10 @@ const demoCopyMap: Record<DemoLocale, Record<string, string>> = {
     themeToLight: 'Switch to light mode',
     themeToDark: 'Switch to dark mode',
     integrationSnippet: 'Integration code',
+    openIntegrationSnippet: 'View integration code',
+    integrationSnippetHint: 'Open and copy a focused example',
+    integrationSnippetDescription: 'Complete React integration example',
+    closeIntegrationSnippet: 'Close integration code',
     copySnippet: 'Copy code',
     copiedSnippet: 'Copied'
   }
@@ -1230,21 +1243,63 @@ const viewerOptions = computed((): FileViewerOptions => {
 })
 
 let copyResetTimer: number | undefined
+const clipboardWriteTimeoutMs = 800
+
+async function openSnippetDialog() {
+  scenarioPickerOpen.value = false
+  samplePickerOpen.value = false
+  mobileActionsOpen.value = false
+  snippetDialogOpen.value = true
+  await nextTick()
+  snippetCloseRef.value?.focus()
+}
+
+function closeSnippetDialog() {
+  if (!snippetDialogOpen.value) {
+    return
+  }
+  snippetDialogOpen.value = false
+  void nextTick(() => snippetLaunchRef.value?.focus())
+}
+
+function copyIntegrationSnippetFallback() {
+  const textarea = document.createElement('textarea')
+  textarea.value = integrationSnippet.value
+  textarea.setAttribute('readonly', 'true')
+  textarea.style.position = 'fixed'
+  textarea.style.opacity = '0'
+  document.body.appendChild(textarea)
+  textarea.select()
+  const copied = document.execCommand('copy')
+  textarea.remove()
+  if (!copied) {
+    throw new Error('Clipboard copy was rejected')
+  }
+}
+
+async function writeIntegrationSnippetToClipboard() {
+  if (!navigator.clipboard?.writeText) {
+    copyIntegrationSnippetFallback()
+    return
+  }
+  let timeoutId: number | undefined
+  try {
+    await Promise.race([
+      navigator.clipboard.writeText(integrationSnippet.value),
+      new Promise<never>((_, reject) => {
+        timeoutId = window.setTimeout(() => reject(new Error('Clipboard write timed out')), clipboardWriteTimeoutMs)
+      })
+    ])
+  } catch {
+    copyIntegrationSnippetFallback()
+  } finally {
+    if (timeoutId) {
+      window.clearTimeout(timeoutId)
+    }
+  }
+}
 
 async function copyIntegrationSnippet() {
-  try {
-    await navigator.clipboard.writeText(integrationSnippet.value)
-  } catch {
-    const textarea = document.createElement('textarea')
-    textarea.value = integrationSnippet.value
-    textarea.setAttribute('readonly', 'true')
-    textarea.style.position = 'fixed'
-    textarea.style.opacity = '0'
-    document.body.appendChild(textarea)
-    textarea.select()
-    document.execCommand('copy')
-    document.body.removeChild(textarea)
-  }
   snippetCopied.value = true
   if (copyResetTimer) {
     window.clearTimeout(copyResetTimer)
@@ -1253,6 +1308,12 @@ async function copyIntegrationSnippet() {
     snippetCopied.value = false
     copyResetTimer = undefined
   }, 1600)
+
+  try {
+    await writeIntegrationSnippetToClipboard()
+  } catch {
+    snippetCopied.value = false
+  }
 }
 
 function closePrintMenu() {
@@ -1586,6 +1647,26 @@ function handleDocumentPointerDown(event: PointerEvent) {
 
 function handleDocumentKeydown(event: KeyboardEvent) {
   const key = event.key.toLowerCase()
+  if (snippetDialogOpen.value) {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      closeSnippetDialog()
+      return
+    }
+    if (event.key === 'Tab') {
+      const focusable = Array.from(snippetDialogRef.value?.querySelectorAll<HTMLButtonElement>('button:not([disabled])') || [])
+      const first = focusable[0]
+      const last = focusable[focusable.length - 1]
+      if (event.shiftKey && document.activeElement === first && last) {
+        event.preventDefault()
+        last.focus()
+      } else if (!event.shiftKey && document.activeElement === last && first) {
+        event.preventDefault()
+        first.focus()
+      }
+    }
+    return
+  }
   if ((event.metaKey || event.ctrlKey) && !event.altKey && key === 'f') {
     event.preventDefault()
     event.stopPropagation()
@@ -1721,23 +1802,44 @@ function updateSampleMenuGeometry() {
           </button>
 
           <div class='panel-body'>
-            <div class='mode-switch'>
-              <button
-                type='button'
-                class='mode-button'
-                :class='{ active: input }'
-                @click='setInputMode(true)'
-              >
-                {{ demoCopy.link }}
-              </button>
-              <button
-                type='button'
-                class='mode-button'
-                :class='{ active: !input }'
-                @click='setInputMode(false)'
-              >
-                {{ demoCopy.upload }}
-              </button>
+            <div class='panel-sticky-controls'>
+              <div class='mode-switch'>
+                <button
+                  type='button'
+                  class='mode-button'
+                  :class='{ active: input }'
+                  @click='setInputMode(true)'
+                >
+                  {{ demoCopy.link }}
+                </button>
+                <button
+                  type='button'
+                  class='mode-button'
+                  :class='{ active: !input }'
+                  @click='setInputMode(false)'
+                >
+                  {{ demoCopy.upload }}
+                </button>
+              </div>
+
+              <section v-if='input' class='source-command'>
+                <label class='field-label' for='preview-url'>{{ demoCopy.address }}</label>
+                <div class='source-command-row'>
+                  <input
+                    id='preview-url'
+                    v-model='url'
+                    class='compact-field'
+                    type='url'
+                    inputmode='url'
+                    autocomplete='url'
+                    :placeholder='demoCopy.addressPlaceholder'
+                    @keyup.enter='openUrlPreview()'
+                  />
+                  <button type='button' class='primary-button' @click='openUrlPreview()'>
+                    {{ demoCopy.preview }}
+                  </button>
+                </div>
+              </section>
             </div>
 
             <template v-if='input'>
@@ -1858,38 +1960,23 @@ function updateSampleMenuGeometry() {
                 </div>
               </div>
 
-              <div class='field-group'>
-                <label class='field-label'>{{ demoCopy.address }}</label>
-                <input
-                  v-model='url'
-                  class='compact-field'
-                  type='text'
-                  :placeholder='demoCopy.addressPlaceholder'
-                  @keyup.enter='openUrlPreview()'
-                />
-              </div>
-
-              <button type='button' class='primary-button' @click='openUrlPreview()'>
-                {{ demoCopy.preview }}
+              <button
+                ref='snippetLaunchRef'
+                type='button'
+                class='snippet-launch'
+                aria-haspopup='dialog'
+                aria-controls='integration-snippet-dialog'
+                @click='openSnippetDialog'
+              >
+                <span class='snippet-launch-icon'>
+                  <Code2 :size='18' :stroke-width='2.3' />
+                </span>
+                <span class='snippet-launch-copy'>
+                  <strong>{{ demoCopy.openIntegrationSnippet }}</strong>
+                  <em>{{ demoCopy.integrationSnippetHint }}</em>
+                </span>
+                <span class='snippet-launch-action'>{{ demoCopy.open }}</span>
               </button>
-
-              <div class='snippet-card'>
-                <div class='snippet-heading'>
-                  <span>{{ demoCopy.integrationSnippet }}</span>
-                  <button
-                    type='button'
-                    class='snippet-copy'
-                    :class='{ copied: snippetCopied }'
-                    :title='snippetCopied ? demoCopy.copiedSnippet : demoCopy.copySnippet'
-                    @click='copyIntegrationSnippet'
-                  >
-                    <Check v-if='snippetCopied' :size='14' :stroke-width='2.5' />
-                    <Copy v-else :size='14' :stroke-width='2.5' />
-                    <strong>{{ snippetCopied ? demoCopy.copiedSnippet : demoCopy.copySnippet }}</strong>
-                  </button>
-                </div>
-                <pre><code>{{ integrationSnippet }}</code></pre>
-              </div>
             </template>
 
             <template v-else>
@@ -2246,6 +2333,63 @@ function updateSampleMenuGeometry() {
         </div>
       </section>
     </main>
+
+    <Teleport to='body'>
+      <Transition name='snippet-dialog'>
+        <div
+          v-if='snippetDialogOpen'
+          class='snippet-dialog-backdrop'
+          :data-demo-theme='resolvedDemoTheme'
+          @click.self='closeSnippetDialog'
+        >
+          <section
+            ref='snippetDialogRef'
+            id='integration-snippet-dialog'
+            class='snippet-dialog-panel'
+            role='dialog'
+            aria-modal='true'
+            aria-labelledby='integration-snippet-title'
+            aria-describedby='integration-snippet-description'
+          >
+            <header class='snippet-dialog-header'>
+              <span class='snippet-dialog-icon'>
+                <Code2 :size='21' :stroke-width='2.3' />
+              </span>
+              <span class='snippet-dialog-title'>
+                <strong id='integration-snippet-title'>{{ demoCopy.integrationSnippet }}</strong>
+                <em id='integration-snippet-description'>{{ demoCopy.integrationSnippetDescription }}</em>
+              </span>
+              <button
+                ref='snippetCloseRef'
+                type='button'
+                class='snippet-dialog-close'
+                :aria-label='demoCopy.closeIntegrationSnippet'
+                @click='closeSnippetDialog'
+              >
+                <X :size='18' :stroke-width='2.5' />
+              </button>
+            </header>
+
+            <pre class='snippet-dialog-code'><code>{{ integrationSnippet }}</code></pre>
+
+            <footer class='snippet-dialog-footer'>
+              <span>{{ demoCopy.integrationSnippetHint }}</span>
+              <button
+                type='button'
+                class='snippet-dialog-copy'
+                :class='{ copied: snippetCopied }'
+                :title='snippetCopied ? demoCopy.copiedSnippet : demoCopy.copySnippet'
+                @click='copyIntegrationSnippet'
+              >
+                <Check v-if='snippetCopied' :size='16' :stroke-width='2.5' />
+                <Copy v-else :size='16' :stroke-width='2.5' />
+                <strong>{{ snippetCopied ? demoCopy.copiedSnippet : demoCopy.copySnippet }}</strong>
+              </button>
+            </footer>
+          </section>
+        </div>
+      </Transition>
+    </Teleport>
   </div>
 </template>
 
@@ -2810,6 +2954,50 @@ function updateSampleMenuGeometry() {
   padding: var(--demo-panel-body-padding);
 }
 
+.panel-sticky-controls {
+  position: sticky;
+  z-index: 12;
+  top: 0;
+  display: grid;
+  gap: var(--demo-panel-body-gap);
+  padding: 0 0 4px;
+  background: linear-gradient(180deg, rgba(247, 250, 248, 0.98) 0%, rgba(247, 250, 248, 0.94) 84%, transparent 100%);
+  backdrop-filter: blur(16px);
+}
+
+.source-command {
+  display: grid;
+  gap: var(--demo-field-gap);
+  padding: 10px;
+  border: 1px solid rgba(33, 163, 102, 0.16);
+  border-radius: 19px;
+  background:
+    linear-gradient(135deg, rgba(33, 163, 102, 0.08), transparent 58%),
+    rgba(255, 255, 255, 0.82);
+  box-shadow: 0 12px 28px rgba(18, 35, 55, 0.07);
+}
+
+.source-command-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: stretch;
+  gap: 8px;
+}
+
+.source-command-row .compact-field {
+  min-width: 0;
+  width: 100%;
+}
+
+.source-command-row .primary-button {
+  min-height: var(--demo-control-height);
+  padding: 0 15px;
+  border-radius: var(--demo-field-radius);
+  white-space: nowrap;
+  box-shadow: 0 12px 24px rgba(33, 163, 102, 0.18);
+}
+
 .sample-picker-open .panel-body {
   overflow: visible;
 }
@@ -2958,80 +3146,239 @@ function updateSampleMenuGeometry() {
   height: 40px;
 }
 
-.snippet-card {
+.snippet-launch {
+  width: 100%;
   min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  padding: 10px;
-  border-radius: 16px;
-  border: 1px solid rgba(20, 35, 53, 0.08);
-  background: rgba(255, 255, 255, 0.74);
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.44);
-}
-
-.snippet-heading {
-  display: flex;
+  min-height: 58px;
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr) auto;
   align-items: center;
-  justify-content: space-between;
   gap: 10px;
+  padding: 9px 10px;
+  border-radius: 17px;
+  border: 1px solid rgba(20, 35, 53, 0.08);
+  background: rgba(255, 255, 255, 0.76);
+  color: #142335;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.38);
+  transition: transform 0.18s ease, border-color 0.18s ease, background-color 0.18s ease, box-shadow 0.18s ease;
 }
 
-.snippet-heading > span {
-  color: #526174;
-  font-size: 12px;
-  font-weight: 900;
+.snippet-launch:hover {
+  transform: translateY(-1px);
+  border-color: rgba(33, 163, 102, 0.24);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: 0 12px 24px rgba(18, 35, 55, 0.08);
 }
 
-.snippet-copy {
-  height: 30px;
-  min-width: 82px;
+.snippet-launch-icon,
+.snippet-dialog-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 5px;
-  border: 0;
-  border-radius: 999px;
   background: rgba(33, 163, 102, 0.12);
   color: #16804f;
-  font: inherit;
+}
+
+.snippet-launch-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+}
+
+.snippet-launch-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.snippet-launch-copy strong {
+  overflow: hidden;
+  color: #142335;
+  font-size: 13px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snippet-launch-copy em {
+  overflow: hidden;
+  color: #718193;
   font-size: 11px;
+  font-style: normal;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.snippet-launch-action {
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(33, 163, 102, 0.1);
+  color: #16804f;
+  font-size: 10px;
   font-weight: 900;
+}
+
+.snippet-dialog-backdrop {
+  position: fixed;
+  z-index: 200;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(12, 24, 31, 0.52);
+  backdrop-filter: blur(14px);
+}
+
+.snippet-dialog-panel {
+  width: min(680px, calc(100vw - 48px));
+  max-height: min(76vh, 620px);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid rgba(255, 255, 255, 0.76);
+  border-radius: 26px;
+  background: rgba(250, 252, 251, 0.96);
+  color: #142335;
+  box-shadow: 0 34px 90px rgba(7, 20, 28, 0.3);
+}
+
+.snippet-dialog-header {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr) 36px;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid rgba(20, 35, 53, 0.08);
+}
+
+.snippet-dialog-icon {
+  width: 44px;
+  height: 44px;
+  border-radius: 15px;
+}
+
+.snippet-dialog-title {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.snippet-dialog-title strong {
+  color: #142335;
+  font-size: 17px;
+  line-height: 1.2;
+}
+
+.snippet-dialog-title em {
+  color: #718193;
+  font-size: 12px;
+  font-style: normal;
+}
+
+.snippet-dialog-close {
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(20, 35, 53, 0.08);
+  border-radius: 999px;
+  background: rgba(20, 35, 53, 0.04);
+  color: #526174;
   cursor: pointer;
 }
 
-.snippet-copy.copied {
-  background: rgba(43, 126, 238, 0.12);
-  color: #2668c9;
+.snippet-dialog-close:hover {
+  background: rgba(20, 35, 53, 0.08);
+  color: #142335;
 }
 
-.snippet-copy strong {
+.snippet-dialog-code {
+  flex: 1;
+  min-height: 0;
+  margin: 0;
+  overflow: auto;
+  padding: 22px 24px;
+  background: #112332;
+  color: #d6f4e5;
+  font-size: 13px;
+  line-height: 1.65;
+  tab-size: 2;
+}
+
+.snippet-dialog-code code {
+  display: block;
+  min-width: max-content;
+  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+}
+
+.snippet-dialog-footer {
+  min-height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 13px 20px;
+  border-top: 1px solid rgba(20, 35, 53, 0.08);
+}
+
+.snippet-dialog-footer > span {
+  color: #718193;
+  font-size: 12px;
+}
+
+.snippet-dialog-copy {
+  min-width: 128px;
+  min-height: 42px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 0 16px;
+  border: 0;
+  border-radius: 14px;
+  background: linear-gradient(135deg, #168757 0%, #2bc87e 100%);
+  color: #ffffff;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(33, 163, 102, 0.2);
+}
+
+.snippet-dialog-copy.copied {
+  background: linear-gradient(135deg, #2668c9 0%, #4a91ef 100%);
+}
+
+.snippet-dialog-copy strong {
   font: inherit;
   white-space: nowrap;
 }
 
-.snippet-card pre {
-  max-height: 118px;
-  margin: 0;
-  overflow: auto;
-  border-radius: 11px;
-  background: #112332;
-  color: #d6f4e5;
-  font-size: 11px;
-  line-height: 1.48;
+.snippet-dialog-enter-active,
+.snippet-dialog-leave-active {
+  transition: opacity 0.2s ease;
 }
 
-.snippet-card code {
-  display: block;
-  min-width: max-content;
-  padding: 10px;
-  font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace;
+.snippet-dialog-enter-active .snippet-dialog-panel,
+.snippet-dialog-leave-active .snippet-dialog-panel {
+  transition: transform 0.22s ease, opacity 0.18s ease;
 }
 
-.field-group {
-  display: flex;
-  flex-direction: column;
-  gap: var(--demo-field-gap);
+.snippet-dialog-enter-from,
+.snippet-dialog-leave-to {
+  opacity: 0;
+}
+
+.snippet-dialog-enter-from .snippet-dialog-panel,
+.snippet-dialog-leave-to .snippet-dialog-panel {
+  opacity: 0;
+  transform: translateY(12px) scale(0.98);
 }
 
 .field-label {
@@ -3814,6 +4161,18 @@ function updateSampleMenuGeometry() {
   box-shadow: 0 24px 64px rgba(0, 0, 0, 0.36);
 }
 
+.demo-shell[data-demo-theme='dark'] .panel-sticky-controls {
+  background: linear-gradient(180deg, rgba(16, 25, 30, 0.98) 0%, rgba(16, 25, 30, 0.94) 84%, transparent 100%);
+}
+
+.demo-shell[data-demo-theme='dark'] .source-command {
+  border-color: rgba(45, 212, 154, 0.2);
+  background:
+    linear-gradient(135deg, rgba(45, 212, 154, 0.1), transparent 58%),
+    rgba(22, 32, 39, 0.92);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.2);
+}
+
 .demo-shell[data-demo-theme='dark'] .brand-card {
   background:
     linear-gradient(135deg, rgba(22, 52, 55, 0.96), rgba(17, 91, 65, 0.9));
@@ -3843,7 +4202,7 @@ function updateSampleMenuGeometry() {
 .demo-shell[data-demo-theme='dark'] .scenario-trigger,
 .demo-shell[data-demo-theme='dark'] .sample-trigger,
 .demo-shell[data-demo-theme='dark'] .upload-card,
-.demo-shell[data-demo-theme='dark'] .snippet-card,
+.demo-shell[data-demo-theme='dark'] .snippet-launch,
 .demo-shell[data-demo-theme='dark'] .scenario-card {
   background: rgba(22, 32, 39, 0.9);
   box-shadow: inset 0 0 0 1px rgba(167, 185, 198, 0.12);
@@ -3857,7 +4216,7 @@ function updateSampleMenuGeometry() {
 
 .demo-shell[data-demo-theme='dark'] .current-copy span,
 .demo-shell[data-demo-theme='dark'] .field-label,
-.demo-shell[data-demo-theme='dark'] .snippet-heading > span,
+.demo-shell[data-demo-theme='dark'] .snippet-launch-copy em,
 .demo-shell[data-demo-theme='dark'] .scenario-trigger-copy em,
 .demo-shell[data-demo-theme='dark'] .scenario-card em,
 .demo-shell[data-demo-theme='dark'] .sample-trigger-copy span,
@@ -3870,6 +4229,7 @@ function updateSampleMenuGeometry() {
 }
 
 .demo-shell[data-demo-theme='dark'] .current-copy strong,
+.demo-shell[data-demo-theme='dark'] .snippet-launch-copy strong,
 .demo-shell[data-demo-theme='dark'] .scenario-trigger-copy strong,
 .demo-shell[data-demo-theme='dark'] .scenario-card strong,
 .demo-shell[data-demo-theme='dark'] .sample-trigger-copy strong,
@@ -3992,17 +4352,60 @@ function updateSampleMenuGeometry() {
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
 }
 
-.demo-shell[data-demo-theme='dark'] .snippet-copy {
+.demo-shell[data-demo-theme='dark'] .snippet-launch-icon,
+.demo-shell[data-demo-theme='dark'] .snippet-launch-action {
   background: rgba(45, 212, 154, 0.14);
   color: #61e5b4;
 }
 
-.demo-shell[data-demo-theme='dark'] .snippet-copy.copied {
-  background: rgba(96, 165, 250, 0.16);
-  color: #9cc7ff;
+.demo-shell[data-demo-theme='dark'] .snippet-launch:hover {
+  border-color: rgba(45, 212, 154, 0.26);
+  background: rgba(22, 32, 39, 0.96);
+  box-shadow: 0 16px 32px rgba(0, 0, 0, 0.28);
 }
 
-.demo-shell[data-demo-theme='dark'] .snippet-card pre {
+.snippet-dialog-backdrop[data-demo-theme='dark'] {
+  background: rgba(3, 10, 14, 0.68);
+}
+
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-panel {
+  border-color: rgba(177, 202, 195, 0.16);
+  background: rgba(16, 25, 30, 0.98);
+  color: #eff7fb;
+  box-shadow: 0 36px 96px rgba(0, 0, 0, 0.54);
+}
+
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-header,
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-footer {
+  border-color: rgba(167, 185, 198, 0.12);
+}
+
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-icon {
+  background: rgba(45, 212, 154, 0.14);
+  color: #61e5b4;
+}
+
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-title strong {
+  color: #eff7fb;
+}
+
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-title em,
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-footer > span {
+  color: #9eb0bf;
+}
+
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-close {
+  border-color: rgba(167, 185, 198, 0.14);
+  background: rgba(239, 247, 251, 0.08);
+  color: #c7d5df;
+}
+
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-close:hover {
+  background: rgba(239, 247, 251, 0.14);
+  color: #ffffff;
+}
+
+.snippet-dialog-backdrop[data-demo-theme='dark'] .snippet-dialog-code {
   background: #08141d;
   color: #d7f8ea;
 }
@@ -4387,9 +4790,8 @@ function updateSampleMenuGeometry() {
   }
 
   .sample-picker-open .scenario-picker,
-  .sample-picker-open .field-group,
-  .sample-picker-open .primary-button,
-  .sample-picker-open .snippet-card {
+  .sample-picker-open .source-command,
+  .sample-picker-open .snippet-launch {
     display: none;
   }
 
@@ -4466,12 +4868,55 @@ function updateSampleMenuGeometry() {
     border-radius: 13px;
   }
 
-  .snippet-card {
+  .snippet-launch {
+    min-height: 56px;
+    border-radius: 15px;
+  }
+
+  .snippet-dialog-backdrop {
+    align-items: flex-end;
+    padding: 10px;
+  }
+
+  .snippet-dialog-panel {
+    width: 100%;
+    max-height: min(78dvh, 620px);
+    border-radius: 24px;
+  }
+
+  .snippet-dialog-header {
+    grid-template-columns: 40px minmax(0, 1fr) 34px;
+    gap: 10px;
+    padding: 14px;
+  }
+
+  .snippet-dialog-icon {
+    width: 40px;
+    height: 40px;
     border-radius: 14px;
   }
 
-  .snippet-card pre {
-    max-height: 104px;
+  .snippet-dialog-close {
+    width: 34px;
+    height: 34px;
+  }
+
+  .snippet-dialog-code {
+    padding: 18px;
+    font-size: 12px;
+  }
+
+  .snippet-dialog-footer {
+    min-height: 66px;
+    padding: 11px 14px;
+  }
+
+  .snippet-dialog-footer > span {
+    display: none;
+  }
+
+  .snippet-dialog-copy {
+    width: 100%;
   }
 
   .upload-card {

--- a/packages/renderers/doc/package.json
+++ b/packages/renderers/doc/package.json
@@ -64,6 +64,7 @@
   "scripts": {
     "build": "tsc -b tsconfig.json",
     "type-check": "tsc -b tsconfig.json",
+    "verify:table-spec": "pnpm build && node scripts/verify-table-spec.mjs",
     "verify:github-34": "pnpm build && node scripts/verify-github-34.mjs",
     "verify:github-87": "pnpm build && node scripts/verify-github-87.mjs"
   },

--- a/packages/renderers/doc/scripts/verify-github-34.mjs
+++ b/packages/renderers/doc/scripts/verify-github-34.mjs
@@ -22,9 +22,26 @@ if (!table.rows.every(row => row.cells.filter(cell => !cell.hidden).length === 5
   throw new Error('Expected every GitHub #34 table row to expose five visible cells')
 }
 
+if (!table.rows.every(row => row.cells.every(cell => (
+  cell.meta?.leftBoundary != null
+  && cell.meta?.rightBoundary != null
+  && cell.meta.rightBoundary > cell.meta.leftBoundary
+)))) {
+  throw new Error('Expected every GitHub #34 table cell to retain a positive grid width')
+}
+
 const rendered = renderMsDoc(parsed)
 if (!rendered.html.includes('<table') || !rendered.html.includes('测试组分A')) {
   throw new Error('Rendered GitHub #34 HTML did not include the restored table content')
+}
+
+const count = pattern => rendered.html.match(pattern)?.length || 0
+if (count(/<tr\b/g) !== count(/<\/tr>/g) || count(/<td\b/g) !== count(/<\/td>/g)) {
+  throw new Error('Rendered GitHub #34 table contains unclosed row or cell markup')
+}
+
+if (rendered.html.includes('#666')) {
+  throw new Error('Rendered GitHub #34 table contains a synthetic gray border')
 }
 
 console.log('[doc] GitHub #34 WPS table fixture parsed and rendered successfully.')

--- a/packages/renderers/doc/scripts/verify-github-34.mjs
+++ b/packages/renderers/doc/scripts/verify-github-34.mjs
@@ -44,4 +44,15 @@ if (rendered.html.includes('#666')) {
   throw new Error('Rendered GitHub #34 table contains a synthetic gray border')
 }
 
+for (const border of [
+  'border-top:1px solid #000000',
+  'border-inline-start:1px solid #000000',
+  'border-inline-end:1px solid #000000',
+  'border-bottom:1px solid #000000'
+]) {
+  if (!rendered.html.includes(border)) {
+    throw new Error(`Rendered GitHub #34 table is missing its ${border} outer edge`)
+  }
+}
+
 console.log('[doc] GitHub #34 WPS table fixture parsed and rendered successfully.')

--- a/packages/renderers/doc/scripts/verify-table-spec.mjs
+++ b/packages/renderers/doc/scripts/verify-table-spec.mjs
@@ -1,0 +1,207 @@
+import assert from 'node:assert/strict'
+import { finalizeTableGrid } from '../dist/msdoc/parser.js'
+import { applyTableStateToCells, tablePropsToState } from '../dist/msdoc/properties.js'
+import { decodeGrpprl, decodeSprm, SprmCodes } from '../dist/msdoc/sprm.js'
+import { mergePropertyArrays } from '../dist/msdoc/styles.js'
+import { renderMsDoc } from '../dist/index.js'
+
+function word(value) {
+  return [value & 0xff, (value >>> 8) & 0xff]
+}
+
+function makeCell(index, borders = {}) {
+  return {
+    index,
+    width: 1200,
+    leftBoundary: index * 1200,
+    rightBoundary: (index + 1) * 1200,
+    borders,
+    merge: 0,
+    vertMerge: 0,
+    vertAlign: 0,
+  }
+}
+
+function makeTableState(operations, cellCount = 2) {
+  return {
+    ...tablePropsToState([]),
+    defTable: {
+      cb: 0,
+      numberOfColumns: cellCount,
+      rgdxaCenter: Array.from({ length: cellCount + 1 }, (_, index) => index * 1200),
+      cells: Array.from({ length: cellCount }, () => ({
+        tcgrf: {},
+        wWidth: 1200,
+        borders: {},
+      })),
+    },
+    operations,
+  }
+}
+
+function renderSingleCellTable(meta, state = makeTableState([], 1)) {
+  return renderMsDoc({
+    blocks: [{
+      type: 'table',
+      id: 'single-cell-table',
+      depth: 1,
+      gridWidthTwips: 1200,
+      state,
+      rows: [{
+        id: 'row',
+        state,
+        gridWidthTwips: 1200,
+        cells: [{
+          id: 'cell',
+          paragraphs: [],
+          meta,
+          colIndex: 0,
+          colspan: 1,
+          rowspan: 1,
+          hidden: false,
+        }],
+      }],
+    }],
+    assets: [],
+    warnings: [],
+    metadata: {},
+  }).html
+}
+
+// TableBrc80Operand: cb, cell range, side mask, then Brc80. Byte 3 is not border data.
+const rightBorder = decodeSprm(
+  SprmCodes.sprmTSetBrc80,
+  Uint8Array.from([7, 0, 2, 0x08, 8, 1, 1, 0]),
+)
+const borderedCells = applyTableStateToCells(makeTableState([rightBorder]))
+assert.equal(borderedCells.length, 2)
+assert.equal(borderedCells[0].borders.right.borderType, 1)
+assert.equal(borderedCells[0].borders.right.lineWidth, 8)
+assert.equal(borderedCells[0].borders.top, undefined)
+assert.equal(borderedCells[0].borders.all, undefined)
+
+// NilBrc explicitly means no border and must never become a fallback gray rule.
+const nilTopBorder = decodeSprm(
+  SprmCodes.sprmTSetBrc,
+  Uint8Array.from([11, 0, 1, 0x01, 0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff]),
+)
+const nilCell = applyTableStateToCells(makeTableState([nilTopBorder], 1))[0]
+assert.equal(nilCell.borders.top.nil, true)
+const renderedNilBorder = renderSingleCellTable(nilCell)
+assert.doesNotMatch(renderedNilBorder, /border-top/)
+assert.doesNotMatch(renderedNilBorder, /#666/)
+
+// Word 97+ paragraph borders use a size-prefixed eight-byte Brc. Parsing
+// them as the four-byte legacy form creates the same kind of phantom rules.
+const nilParagraphBorder = decodeSprm(
+  SprmCodes.sprmPBrcLeft,
+  Uint8Array.from([8, 0, 0, 0, 0, 0xff, 0xff, 0xff, 0xff]),
+)
+assert.equal(nilParagraphBorder.value.nil, true)
+
+// VertMergeOperand targets one cell, not an ItcFirstLim range.
+const verticalRestart = decodeSprm(SprmCodes.sprmTVertMerge, Uint8Array.from([2, 1, 3]))
+const verticallyMergedCells = applyTableStateToCells(makeTableState([verticalRestart]))
+assert.equal(verticallyMergedCells[0].vertMerge, 0)
+assert.equal(verticallyMergedCells[1].vertMerge, 3)
+
+// TInsertOperand is a fixed four-byte structure and creates the missing cell definitions.
+const initialInsert = decodeSprm(SprmCodes.sprmTInsert, Uint8Array.from([0, 1, ...word(1200)]))
+const insert = decodeSprm(SprmCodes.sprmTInsert, Uint8Array.from([1, 2, ...word(800)]))
+const insertOnlyState = { ...tablePropsToState([]), operations: [initialInsert, insert] }
+const insertedCells = applyTableStateToCells(insertOnlyState)
+assert.equal(insertedCells.length, 3)
+assert.deepEqual(insertedCells.map(cell => cell.width), [1200, 800, 800])
+assert.deepEqual(insertedCells.map(cell => cell.index), [0, 1, 2])
+assert.deepEqual(insertedCells.map(cell => cell.leftBoundary), [0, 1200, 2000])
+assert.deepEqual(insertedCells.map(cell => cell.rightBoundary), [1200, 2000, 2800])
+assert.equal(applyTableStateToCells(makeTableState([insert], 1)).length, 1)
+
+// ftsNil/ftsAuto widths are undefined and must not collapse a valid TDefTable grid.
+const nilPreferredWidth = decodeSprm(
+  SprmCodes.sprmTCellWidth,
+  Uint8Array.from([5, 0, 1, 0, 0, 0]),
+)
+const widthPreservedCell = applyTableStateToCells(makeTableState([nilPreferredWidth], 1))[0]
+assert.equal(widthPreservedCell.width, 1200)
+
+// CSSA keeps its side mask before ftsWidth; padding and spacing are distinct operations.
+const padding = decodeSprm(
+  SprmCodes.sprmTCellPaddingDefault,
+  Uint8Array.from([6, 0, 1, 0x0a, 3, ...word(120)]),
+)
+const spacing = decodeSprm(
+  SprmCodes.sprmTCellSpacingDefault,
+  Uint8Array.from([6, 0, 1, 0x0f, 0x13, ...word(120)]),
+)
+const spacedCell = applyTableStateToCells(makeTableState([padding, spacing], 1))[0]
+assert.deepEqual(spacedCell.paddingTwips, { left: 120, right: 120 })
+assert.deepEqual(spacedCell.spacingTwips, { top: 120, left: 120, bottom: 120, right: 120 })
+const spacedHtml = renderSingleCellTable(spacedCell)
+assert.match(spacedHtml, /border-spacing:8px 8px/)
+assert.match(spacedHtml, /padding-inline-start:8px/)
+
+// Fixed-size table operands must not desynchronize the following grpprl entry.
+const grpprl = Uint8Array.from([
+  ...word(SprmCodes.sprmTDxaCol), 0, 2, ...word(900),
+  ...word(SprmCodes.sprmTMerge), 0, 2,
+])
+const decodedGrpprl = decodeGrpprl(grpprl, 0, grpprl.length)
+assert.deepEqual(decodedGrpprl.map(property => property.name), ['columnWidth', 'merge'])
+assert.equal(decodedGrpprl[0].value.width, 900)
+
+// Range operations are ordered differences; merging style/direct properties must retain all sides.
+const topBorder = decodeSprm(
+  SprmCodes.sprmTSetBrc80,
+  Uint8Array.from([7, 0, 1, 0x01, 8, 1, 1, 0]),
+)
+const bottomBorder = decodeSprm(
+  SprmCodes.sprmTSetBrc80,
+  Uint8Array.from([7, 0, 1, 0x04, 8, 1, 1, 0]),
+)
+const retainedOperations = mergePropertyArrays([topBorder], [bottomBorder])
+assert.equal(retainedOperations.length, 2)
+const retainedCell = applyTableStateToCells(makeTableState(retainedOperations, 1))[0]
+assert.equal(retainedCell.borders.top.borderType, 1)
+assert.equal(retainedCell.borders.bottom.borderType, 1)
+
+// TableShadeOperand contains a ten-byte Shd, not a one-byte color index.
+const shading = decodeSprm(
+  SprmCodes.sprmTSetShdOdd,
+  Uint8Array.from([12, 0, 3, 0, 0, 0xff, 0, 0xff, 0xff, 0xff, 0, 1, 0]),
+)
+const shadedCells = applyTableStateToCells(makeTableState([shading], 3))
+assert.equal(shadedCells[0].shading.pattern, 1)
+assert.equal(shadedCells[1].shading, undefined)
+assert.equal(shadedCells[2].shading.pattern, 1)
+
+// Only continuations with a valid restart are hidden. The restart cell adopts
+// the merged region's outer geometry and closing borders.
+const horizontalRows = [{
+  cells: [
+    { meta: { ...makeCell(0), merge: 3 } },
+    { meta: { ...makeCell(1), merge: 1 } },
+    { meta: { ...makeCell(2), merge: 1, borders: { right: { borderType: 1, lineWidth: 8 } } } },
+  ],
+}]
+finalizeTableGrid(horizontalRows)
+assert.equal(horizontalRows[0].cells[0].colspan, 3)
+assert.equal(horizontalRows[0].cells[0].meta.rightBoundary, 3600)
+assert.equal(horizontalRows[0].cells[0].meta.borders.right.borderType, 1)
+assert.equal(horizontalRows[0].cells[1].hidden, true)
+assert.equal(horizontalRows[0].cells[2].hidden, true)
+
+const orphanContinuationRows = [{ cells: [{ meta: { ...makeCell(0), merge: 1 } }] }]
+finalizeTableGrid(orphanContinuationRows)
+assert.equal(orphanContinuationRows[0].cells[0].hidden, false)
+
+const verticalRows = [
+  { cells: [{ meta: { ...makeCell(0), vertMerge: 3 } }] },
+  { cells: [{ meta: { ...makeCell(0), vertMerge: 1, borders: { bottom: { borderType: 1, lineWidth: 8 } } } }] },
+]
+finalizeTableGrid(verticalRows)
+assert.equal(verticalRows[0].cells[0].rowspan, 2)
+assert.equal(verticalRows[0].cells[0].meta.borders.bottom.borderType, 1)
+assert.equal(verticalRows[1].cells[0].hidden, true)
+
+console.log('[doc] MS-DOC table operand and rendering regression checks passed.')

--- a/packages/renderers/doc/src/msdoc/parser.ts
+++ b/packages/renderers/doc/src/msdoc/parser.ts
@@ -353,25 +353,40 @@ function buildParagraphModel(
   };
 }
 
-function finalizeTableGrid(rows: TableRowBlock[]): void {
+export function finalizeTableGrid(rows: TableRowBlock[]): void {
   for (const row of rows) {
-    for (let i = 0; i < row.cells.length; i += 1) {
-      const cell = row.cells[i]!;
-      const merge = cell.meta?.merge || 0;
-      cell.colIndex = i;
+    row.cells.forEach((cell, index) => {
+      cell.colIndex = index;
       cell.colspan = 1;
       cell.rowspan = 1;
       cell.hidden = false;
+    });
+    for (let i = 0; i < row.cells.length; i += 1) {
+      const cell = row.cells[i]!;
+      const merge = cell.meta?.merge || 0;
       if (merge === 1) {
-        cell.hidden = true;
         continue;
       }
       if (merge > 1) {
         let j = i + 1;
         while (j < row.cells.length && (row.cells[j]!.meta?.merge || 0) === 1) {
           row.cells[j]!.hidden = true;
-          cell.colspan += 1;
+          cell.colspan = (cell.colspan || 1) + 1;
           j += 1;
+        }
+        const lastCell = row.cells[j - 1];
+        if (cell.meta && lastCell?.meta && lastCell !== cell) {
+          cell.meta.rightBoundary = lastCell.meta.rightBoundary;
+          if (cell.meta.leftBoundary != null && cell.meta.rightBoundary != null) {
+            cell.meta.width = Math.max(0, cell.meta.rightBoundary - cell.meta.leftBoundary);
+          }
+          const rightBorder = lastCell.meta.borders?.right;
+          if (rightBorder) {
+            cell.meta.borders = {
+              ...(cell.meta.borders || {}),
+              right: rightBorder,
+            };
+          }
         }
       }
     }
@@ -383,7 +398,6 @@ function finalizeTableGrid(rows: TableRowBlock[]): void {
       if (cell.hidden) continue;
       const vertMerge = cell.meta?.vertMerge || 0;
       if (vertMerge === 1) {
-        cell.hidden = true;
         continue;
       }
       if (vertMerge > 1) {
@@ -404,9 +418,41 @@ function finalizeTableGrid(rows: TableRowBlock[]): void {
           cell.rowspan = (cell.rowspan || 1) + 1;
           nextIndex += 1;
         }
+        const bottomCell = rows[nextIndex - 1]?.cells[cell.colIndex || 0];
+        const bottomBorder = bottomCell?.meta?.borders?.bottom;
+        if (cell.meta && bottomCell?.meta && bottomCell !== cell && bottomBorder) {
+          cell.meta.borders = {
+            ...(cell.meta.borders || {}),
+            bottom: bottomBorder,
+          };
+        }
       }
     }
   }
+}
+
+function resolveTableGridBorders(rows: TableRowBlock[]): void {
+  const hasOwnBorder = (borders: Record<string, unknown>, side: string) => (
+    Object.prototype.hasOwnProperty.call(borders, side)
+  );
+  rows.forEach((row, rowIndex) => {
+    row.cells.forEach((cell) => {
+      if (cell.hidden || !cell.meta) return;
+      const explicit = { ...(cell.meta.borders || {}) };
+      const table = row.state.borders || {};
+      const startColumn = cell.colIndex || 0;
+      const endColumn = startColumn + (cell.colspan || 1);
+      const endRow = rowIndex + (cell.rowspan || 1);
+      const assignFallback = (side: string, border: typeof table.top) => {
+        if (!hasOwnBorder(explicit, side) && border) explicit[side] = border;
+      };
+      assignFallback('top', rowIndex === 0 ? table.top : table.horizontalInside);
+      assignFallback('bottom', endRow >= rows.length ? table.bottom : table.horizontalInside);
+      assignFallback('left', startColumn === 0 ? table.left : table.verticalInside);
+      assignFallback('right', endColumn >= row.cells.length ? table.right : table.verticalInside);
+      cell.meta.borders = explicit;
+    });
+  });
 }
 
 function paragraphToBlock(paragraph: ParagraphModel): ParagraphBlock {
@@ -424,7 +470,7 @@ function paragraphToBlock(paragraph: ParagraphModel): ParagraphBlock {
 function normalizeRowEndOnlyTables(paragraphs: ParagraphModel[]): void {
   for (let index = 0; index < paragraphs.length; index += 1) {
     const rowEnd = paragraphs[index]!;
-    const cellCount = rowEnd.tableState.defTable?.cells?.length || 0;
+    const cellCount = applyTableStateToCells(rowEnd.tableState).length;
     if (!rowEnd.paraState.tableRowEnd || !cellCount) continue;
 
     rowEnd.paraState.inTable = true;
@@ -493,6 +539,7 @@ function buildTableBlock(tableParagraphs: ParagraphModel[]): TableBlock {
   }
 
   finalizeTableGrid(rows);
+  resolveTableGridBorders(rows);
 
   const gridWidthTwips = rows.find((row) => row.gridWidthTwips)?.gridWidthTwips || 0;
   const depth = Math.max(...tableParagraphs.map((paragraph) => getTableDepth(paragraph.paraState)), 1);

--- a/packages/renderers/doc/src/msdoc/parser.ts
+++ b/packages/renderers/doc/src/msdoc/parser.ts
@@ -433,7 +433,12 @@ export function finalizeTableGrid(rows: TableRowBlock[]): void {
 
 function resolveTableGridBorders(rows: TableRowBlock[]): void {
   const hasOwnBorder = (borders: Record<string, unknown>, side: string) => (
-    Object.prototype.hasOwnProperty.call(borders, side)
+    Object.prototype.hasOwnProperty.call(borders, side) && (() => {
+      const border = borders[side] as { borderType?: number; nil?: boolean } | undefined;
+      // An all-zero BRC is an empty cell-level value and still inherits the
+      // table edge/inside border. NilBrc is the explicit "no border" value.
+      return Boolean(border?.nil || border?.borderType);
+    })()
   );
   rows.forEach((row, rowIndex) => {
     row.cells.forEach((cell) => {

--- a/packages/renderers/doc/src/msdoc/properties.ts
+++ b/packages/renderers/doc/src/msdoc/properties.ts
@@ -196,6 +196,7 @@ export function tablePropsToState(properties: DecodedProperty[]): TableState {
     autoFit: undefined,
     widthBefore: undefined,
     widthAfter: undefined,
+    borders: {},
     defTable: undefined,
     operations: [],
   };
@@ -220,6 +221,7 @@ export function tablePropsToState(properties: DecodedProperty[]): TableState {
       case 'autoFit': state.autoFit = prop.value; break;
       case 'widthBefore': state.widthBefore = prop.value; break;
       case 'widthAfter': state.widthAfter = prop.value; break;
+      case 'tableBorders': state.borders = (prop.value as TableState['borders']) || {}; break;
       case 'defTable': state.defTable = prop.value as TableState['defTable']; break;
       default:
         state.operations.push(prop);
@@ -255,10 +257,11 @@ export function rangeApply<T>(list: T[], range: { first: number; lim: number } |
 
 export function applyTableStateToCells(tableState: TableState): TableCellMeta[] {
   const def = tableState?.defTable;
-  if (!def || !Array.isArray(def.cells)) return [];
-  const cells: TableCellMeta[] = def.cells.map((cell, index) => ({
+  const cells: TableCellMeta[] = (def?.cells || []).map((cell, index) => ({
     index,
-    width: cell?.wWidth as number | undefined,
+    width: def?.rgdxaCenter?.[index + 1] != null && def?.rgdxaCenter?.[index] != null
+      ? Math.max(0, def.rgdxaCenter[index + 1]! - def.rgdxaCenter[index]!)
+      : cell?.wWidth as number | undefined,
     ftsWidth: cell?.tcgrf?.ftsWidth as number | undefined,
     borders: (cell?.borders || {}) as Record<string, BorderSpec>,
     merge: (cell?.tcgrf?.horzMerge as number | undefined) || 0,
@@ -268,12 +271,52 @@ export function applyTableStateToCells(tableState: TableState): TableCellMeta[] 
     noWrap: Boolean(cell?.tcgrf?.noWrap),
     hideMark: Boolean(cell?.tcgrf?.hideMark),
     textFlow: (cell?.tcgrf?.textFlow as number | undefined) || 0,
-    rightBoundary: def.rgdxaCenter?.[index + 1],
-    leftBoundary: def.rgdxaCenter?.[index],
+    rightBoundary: def?.rgdxaCenter?.[index + 1],
+    leftBoundary: def?.rgdxaCenter?.[index],
   }));
+  let geometryChanged = false;
+  const initialLeftBoundary = cells[0]?.leftBoundary || 0;
 
   for (const op of tableState.operations || []) {
     switch (op.name) {
+      case 'insertCells': {
+        // Word commonly emits TDefTable for legacy readers and TInsert for
+        // readers that process sprmPTableProps. They are alternative cell
+        // definitions, not cumulative instructions.
+        if (def?.cells?.length) break;
+        const value = op.value as { itcFirst?: number; ctc?: number; dxaCol?: number } | null;
+        const first = Math.min(cells.length, Math.max(0, value?.itcFirst || 0));
+        const count = Math.min(63 - cells.length, Math.max(0, value?.ctc || 0));
+        const width = Math.max(0, value?.dxaCol || 0);
+        if (count) {
+          cells.splice(first, 0, ...Array.from({ length: count }, (_, offset) => ({
+            index: first + offset,
+            width,
+            borders: {},
+            merge: 0,
+            vertMerge: 0,
+            vertAlign: 0,
+            fitText: false,
+            noWrap: false,
+            hideMark: false,
+            textFlow: 0,
+          })));
+          geometryChanged = true;
+        }
+        break;
+      }
+      case 'deleteCells': {
+        const range = op.value as { first: number; lim: number } | null;
+        if (range) {
+          const first = Math.max(0, range.first || 0);
+          const count = Math.max(0, (range.lim || first) - first);
+          if (count) {
+            cells.splice(first, count);
+            geometryChanged = true;
+          }
+        }
+        break;
+      }
       case 'merge':
         rangeApply(cells, op.value as { first: number; lim: number }, (cell, idx) => {
           const range = op.value as { first: number };
@@ -285,25 +328,79 @@ export function applyTableStateToCells(tableState: TableState): TableCellMeta[] 
         rangeApply(cells, op.value as { first: number; lim: number }, (cell) => { cell.merge = 0; });
         break;
       case 'cellWidth':
-      case 'columnWidth':
         rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell) => {
           const value = op.value as { width?: number; ftsWidth?: number };
-          cell.width = value.width;
           cell.ftsWidth = value.ftsWidth;
+          // ftsNil and ftsAuto carry no usable preferred width. Preserve the
+          // TDefTable boundary width instead of collapsing the cell to zero.
+          if ((value.ftsWidth === 2 || value.ftsWidth === 3) && value.width != null) {
+            cell.width = value.width;
+          }
         });
         break;
-      case 'vertMerge':
-        rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell) => { cell.vertMerge = (op.value as { value: number }).value; });
+      case 'columnWidth':
+        rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell) => {
+          cell.width = Math.max(0, (op.value as { width?: number }).width || 0);
+          geometryChanged = true;
+        });
         break;
+      case 'vertMerge': {
+        const value = op.value as { index?: number; value?: number } | null;
+        const cell = value?.index != null ? cells[value.index] : undefined;
+        if (cell) cell.vertMerge = value?.value || 0;
+        break;
+      }
       case 'vertAlign':
         rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell) => { cell.vertAlign = (op.value as { value: number }).value; });
         break;
       case 'setBorder':
-        rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell) => { cell.borders = { ...(cell.borders || {}), all: (op.value as { border: BorderSpec }).border }; });
+        rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell) => {
+          const value = op.value as { border: BorderSpec; bordersToApply: number };
+          const borders = { ...(cell.borders || {}) };
+          if (value.bordersToApply & 0x01) borders.top = value.border;
+          if (value.bordersToApply & 0x02) borders.left = value.border;
+          if (value.bordersToApply & 0x04) borders.bottom = value.border;
+          if (value.bordersToApply & 0x08) borders.right = value.border;
+          if (value.bordersToApply & 0x10) borders.diagonalDown = value.border;
+          if (value.bordersToApply & 0x20) borders.diagonalUp = value.border;
+          cell.borders = borders;
+        });
         break;
       case 'setShading':
-        rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell) => { cell.shading = (op.value as { value: unknown }).value; });
+        rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell, index) => {
+          const value = op.value as { range: { first: number }; shading?: TableCellMeta['shading']; odd?: boolean };
+          if (!value.odd || (index - value.range.first) % 2 === 0) cell.shading = value.shading;
+        });
         break;
+      case 'cellPadding':
+      case 'cellSpacing': {
+        const value = op.value as {
+          range?: { first: number; lim: number };
+          sides?: number;
+          ftsWidth?: number;
+          width?: number;
+        } | null;
+        const isTwips = value?.ftsWidth === 3 || (op.name === 'cellSpacing' && value?.ftsWidth === 0x13);
+        if (!value?.range || !isTwips || value.width == null) break;
+        rangeApply(cells, value.range, (cell) => {
+          const key = op.name === 'cellPadding' ? 'paddingTwips' : 'spacingTwips';
+          const sides = { ...(cell[key] || {}) };
+          if ((value.sides || 0) & 0x01) sides.top = value.width;
+          if ((value.sides || 0) & 0x02) sides.left = value.width;
+          if ((value.sides || 0) & 0x04) sides.bottom = value.width;
+          if ((value.sides || 0) & 0x08) sides.right = value.width;
+          cell[key] = sides;
+        });
+        break;
+      }
+      case 'defaultShading': {
+        const value = op.value as { start?: number; values?: TableCellMeta['shading'][] } | null;
+        (value?.values || []).forEach((shading, offset) => {
+          const cell = cells[(value?.start || 0) + offset];
+          if (cell) cell.shading = shading;
+        });
+        break;
+      }
       case 'fitText':
         rangeApply(cells, (op.value as { range: { first: number; lim: number } }).range, (cell) => { cell.fitText = Boolean((op.value as { value: unknown }).value); });
         break;
@@ -317,6 +414,17 @@ export function applyTableStateToCells(tableState: TableState): TableCellMeta[] 
         break;
     }
   }
+
+  if (geometryChanged) {
+    let boundary = initialLeftBoundary;
+    cells.forEach((cell) => {
+      const width = Math.max(0, cell.width || 0);
+      cell.leftBoundary = boundary;
+      boundary += width;
+      cell.rightBoundary = boundary;
+    });
+  }
+  cells.forEach((cell, index) => { cell.index = index; });
 
   return cells;
 }

--- a/packages/renderers/doc/src/msdoc/sprm.ts
+++ b/packages/renderers/doc/src/msdoc/sprm.ts
@@ -8,8 +8,10 @@ import type {
   RangeBorderOperand,
   RangeValueOperand,
   RangeWidthOperand,
+  ShadingSpec,
   TDefTableOperand,
   TInsertOperand,
+  TableBorders,
   TableWidthOperand,
   Tcgrf,
 } from '../types.js';
@@ -141,6 +143,7 @@ export const SprmCodes = {
   sprmTTableBorders: 0xd613,
   sprmTTableWidth: 0xf614,
   sprmTFAutofit: 0x3615,
+  sprmTDefTableShd2nd: 0xd616,
   sprmTWidthBefore: 0xf617,
   sprmTWidthAfter: 0xf618,
   sprmTSetBrc80: 0xd620,
@@ -156,11 +159,15 @@ export const SprmCodes = {
   sprmTSetShdOdd: 0xd62e,
   sprmTSetBrc: 0xd62f,
   sprmTCellPadding: 0xd632,
-  sprmTCellPaddingDefault: 0xd633,
+  sprmTCellSpacingDefault: 0xd633,
+  sprmTCellPaddingDefault: 0xd634,
   sprmTCellWidth: 0xd635,
   sprmTFitText: 0xf636,
   sprmTFCellNoWrap: 0xd639,
   sprmTIstd: 0x563a,
+  sprmTDefTableShdRaw: 0xd670,
+  sprmTDefTableShdRaw2nd: 0xd671,
+  sprmTDefTableShdRaw3rd: 0xd672,
 } as const;
 
 const VARIABLE_OPERAND_CODES = new Set<number>([
@@ -172,17 +179,20 @@ const VARIABLE_OPERAND_CODES = new Set<number>([
   SprmCodes.sprmTDefTableShd,
   SprmCodes.sprmTDefTableShd80,
   SprmCodes.sprmTDefTableShd3rd,
+  SprmCodes.sprmTDefTableShd2nd,
+  SprmCodes.sprmTDefTableShdRaw,
+  SprmCodes.sprmTDefTableShdRaw2nd,
+  SprmCodes.sprmTDefTableShdRaw3rd,
   SprmCodes.sprmTSetBrc80,
   SprmCodes.sprmTSetBrc,
   SprmCodes.sprmTSetShd,
   SprmCodes.sprmTSetShdOdd,
   SprmCodes.sprmTCellPadding,
+  SprmCodes.sprmTCellSpacingDefault,
   SprmCodes.sprmTCellPaddingDefault,
   SprmCodes.sprmTCellWidth,
   SprmCodes.sprmTVertAlign,
   SprmCodes.sprmTVertMerge,
-  SprmCodes.sprmTTextFlow,
-  SprmCodes.sprmTDxaCol,
 ]);
 
 export function getSprmGroup(sprm: number): number {
@@ -217,10 +227,36 @@ function parseItcFirstLim(bytes: Uint8Array, offset = 0): ItcRange {
 function parseBrc80(bytes: Uint8Array, offset = 0): BorderSpec | null {
   if (offset + 4 > bytes.length) return null;
   const brc = u32(bytes, offset) >>> 0;
+  if (brc === 0xffffffff) return { raw: brc, nil: true };
   const lineWidth = brc & 0xff;
   const borderType = (brc >> 8) & 0xff;
   const color = (brc >> 16) & 0xff;
-  return { raw: brc, lineWidth, borderType, color };
+  const flags = (brc >>> 24) & 0xff;
+  return {
+    raw: brc,
+    lineWidth,
+    borderType,
+    color,
+    space: flags & 0x1f,
+    shadow: Boolean(flags & 0x20),
+    frame: Boolean(flags & 0x40),
+  };
+}
+
+function parseBrc(bytes: Uint8Array, offset = 0): BorderSpec | null {
+  if (offset + 8 > bytes.length) return null;
+  const colorRef = u32(bytes, offset) >>> 0;
+  const packed = u32(bytes, offset + 4) >>> 0;
+  if (packed === 0xffffffff) return { raw: packed, colorRef, nil: true };
+  return {
+    raw: packed,
+    colorRef,
+    lineWidth: packed & 0xff,
+    borderType: (packed >>> 8) & 0xff,
+    space: (packed >>> 16) & 0x1f,
+    shadow: Boolean(packed & (1 << 21)),
+    frame: Boolean(packed & (1 << 22)),
+  };
 }
 
 function parseTcgrf(bytes: Uint8Array, offset = 0): Tcgrf {
@@ -250,6 +286,62 @@ function parseTc80(bytes: Uint8Array, offset = 0): { tcgrf: Tcgrf; wWidth: numbe
       right: parseBrc80(bytes, offset + 16) || {},
     },
   };
+}
+
+function parseShd80(bytes: Uint8Array, offset = 0): ShadingSpec | null {
+  if (offset + 2 > bytes.length) return null;
+  const raw = u16(bytes, offset);
+  const foregroundColorIndex = raw & 0x1f;
+  const backgroundColorIndex = (raw >>> 5) & 0x1f;
+  const pattern = (raw >>> 10) & 0x3f;
+  return {
+    foregroundColorIndex,
+    backgroundColorIndex,
+    pattern,
+    auto: pattern === 0,
+    nil: raw === 0xffff,
+    legacy: true,
+  };
+}
+
+function parseShd(bytes: Uint8Array, offset = 0): ShadingSpec | null {
+  if (offset + 10 > bytes.length) return null;
+  const foregroundColorRef = u32(bytes, offset) >>> 0;
+  const backgroundColorRef = u32(bytes, offset + 4) >>> 0;
+  const pattern = u16(bytes, offset + 8);
+  return {
+    foregroundColorRef,
+    backgroundColorRef,
+    pattern,
+    auto: pattern === 0,
+    nil: pattern === 0xffff,
+  };
+}
+
+function parseTableBorders(bytes: Uint8Array, legacy: boolean): TableBorders | null {
+  const borderSize = legacy ? 4 : 8;
+  if (!bytes.length || bytes.length < 1 + borderSize * 6) return null;
+  const parse = legacy ? parseBrc80 : parseBrc;
+  const names: Array<keyof TableBorders> = [
+    'top', 'left', 'bottom', 'right', 'horizontalInside', 'verticalInside',
+  ];
+  const borders: TableBorders = {};
+  names.forEach((name, index) => {
+    const border = parse(bytes, 1 + index * borderSize);
+    if (border) borders[name] = border;
+  });
+  return borders;
+}
+
+function parseDefaultShading(bytes: Uint8Array, start: number, legacy: boolean) {
+  const size = legacy ? 2 : 10;
+  const count = Math.floor(Math.min(bytes[0] ?? 0, Math.max(0, bytes.length - 1)) / size);
+  const values: ShadingSpec[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const shading = legacy ? parseShd80(bytes, 1 + index * size) : parseShd(bytes, 1 + index * size);
+    if (shading) values.push(shading);
+  }
+  return { start, values };
 }
 
 function parseTDefTableOperand(bytes: Uint8Array): TDefTableOperand | null {
@@ -295,14 +387,65 @@ function parseRangeWidthOperand(bytes: Uint8Array): RangeWidthOperand | null {
   };
 }
 
-function parseRangeBrcOperand(bytes: Uint8Array): RangeBorderOperand | null {
-  if (!bytes.length) return null;
+function parseCssaOperand(bytes: Uint8Array): RangeWidthOperand | null {
+  if (bytes.length < 7) return null;
+  const width = u16(bytes, 5);
   return {
     cb: bytes[0] ?? 0,
     range: parseItcFirstLim(bytes, 1),
-    border: parseBrc80(bytes, 3) || {},
-    extra: bytes.subarray(7),
+    sides: bytes[3] ?? 0,
+    ftsWidth: bytes[4] ?? 0,
+    width,
+    wWidth: width,
+  };
+}
+
+function parseRangeBrcOperand(bytes: Uint8Array): RangeBorderOperand | null {
+  if (bytes.length < 8) return null;
+  return {
+    cb: bytes[0] ?? 0,
+    range: parseItcFirstLim(bytes, 1),
+    bordersToApply: bytes[3] ?? 0,
+    border: parseBrc80(bytes, 4) || { nil: true },
+    extra: bytes.subarray(8),
   } as RangeBorderOperand;
+}
+
+function parseRangeBrcOperand97(bytes: Uint8Array): RangeBorderOperand | null {
+  if (bytes.length < 12) return null;
+  return {
+    cb: bytes[0] ?? 0,
+    range: parseItcFirstLim(bytes, 1),
+    bordersToApply: bytes[3] ?? 0,
+    border: parseBrc(bytes, 4) || { nil: true },
+    extra: bytes.subarray(12),
+  } as RangeBorderOperand;
+}
+
+function parseTableShadeOperand(bytes: Uint8Array, odd = false) {
+  if (bytes.length < 13) return null;
+  return {
+    cb: bytes[0] ?? 0,
+    range: parseItcFirstLim(bytes, 1),
+    shading: parseShd(bytes, 3),
+    odd,
+  };
+}
+
+function parseVertMergeOperand(bytes: Uint8Array) {
+  if (bytes.length < 3) return null;
+  return { cb: bytes[0] ?? 0, index: bytes[1] ?? 0, value: bytes[2] ?? 0 };
+}
+
+function parseFixedRangeValueOperand(bytes: Uint8Array) {
+  if (bytes.length < 3) return null;
+  return { range: parseItcFirstLim(bytes, 0), value: bytes[2] ?? 0 };
+}
+
+function parseFixedRangeWidthOperand(bytes: Uint8Array): RangeWidthOperand | null {
+  if (bytes.length < 4) return null;
+  const width = i16(bytes, 2);
+  return { range: parseItcFirstLim(bytes, 0), width, wWidth: width };
 }
 
 function parseTTableWidth(bytes: Uint8Array): TableWidthOperand | null {
@@ -316,22 +459,12 @@ function parseTTableWidth(bytes: Uint8Array): TableWidthOperand | null {
 }
 
 function parseTInsertOperand(bytes: Uint8Array): TInsertOperand | null {
-  if (!bytes.length) return null;
-  const cb = bytes[0] ?? 0;
-  const itc = parseItcFirstLim(bytes, 1);
-  const ctc = itc.lim - itc.first;
-  let offset = 3;
-  const dxaCol: number[] = [];
-  for (let i = 0; i < ctc && offset + 2 <= bytes.length; i += 1) {
-    dxaCol.push(i16(bytes, offset));
-    offset += 2;
-  }
-  const cells: Array<ReturnType<typeof parseTc80>> = [];
-  for (let i = 0; i < ctc && offset + 20 <= bytes.length; i += 1) {
-    cells.push(parseTc80(bytes, offset));
-    offset += 20;
-  }
-  return { cb, range: itc, itcFirst: itc.first, ctc, dxaCol, cells } as TInsertOperand;
+  if (bytes.length < 4) return null;
+  return {
+    itcFirst: bytes[0] ?? 0,
+    ctc: bytes[1] ?? 0,
+    dxaCol: u16(bytes, 2),
+  };
 }
 
 export function getSprmOperandLength(buffer: Uint8Array, offset: number, sprm: number): number {
@@ -437,18 +570,18 @@ export function decodeSprm(sprm: number, operandBytes: Uint8Array): DecodedPrope
     case SprmCodes.sprmPDxaWidth: return setMeta('para', 'frameWidth', i16(bytes, 0), raw, bytes);
     case SprmCodes.sprmPPc: return setMeta('para', 'framePosition', bytes[0] ?? 0, raw, bytes);
     case SprmCodes.sprmPWr: return setMeta('para', 'frameWrap', bytes[0] ?? 0, raw, bytes);
-    case SprmCodes.sprmPBrcTop80:
-    case SprmCodes.sprmPBrcTop: return setMeta('para', 'borderTop', parseBrc80(bytes, 0), raw, bytes);
-    case SprmCodes.sprmPBrcLeft80:
-    case SprmCodes.sprmPBrcLeft: return setMeta('para', 'borderLeft', parseBrc80(bytes, 0), raw, bytes);
-    case SprmCodes.sprmPBrcBottom80:
-    case SprmCodes.sprmPBrcBottom: return setMeta('para', 'borderBottom', parseBrc80(bytes, 0), raw, bytes);
-    case SprmCodes.sprmPBrcRight80:
-    case SprmCodes.sprmPBrcRight: return setMeta('para', 'borderRight', parseBrc80(bytes, 0), raw, bytes);
-    case SprmCodes.sprmPBrcBetween80:
-    case SprmCodes.sprmPBrcBetween: return setMeta('para', 'borderBetween', parseBrc80(bytes, 0), raw, bytes);
-    case SprmCodes.sprmPBrcBar80:
-    case SprmCodes.sprmPBrcBar: return setMeta('para', 'borderBar', parseBrc80(bytes, 0), raw, bytes);
+    case SprmCodes.sprmPBrcTop80: return setMeta('para', 'borderTop', parseBrc80(bytes, 0), raw, bytes);
+    case SprmCodes.sprmPBrcTop: return setMeta('para', 'borderTop', parseBrc(bytes, 1), raw, bytes);
+    case SprmCodes.sprmPBrcLeft80: return setMeta('para', 'borderLeft', parseBrc80(bytes, 0), raw, bytes);
+    case SprmCodes.sprmPBrcLeft: return setMeta('para', 'borderLeft', parseBrc(bytes, 1), raw, bytes);
+    case SprmCodes.sprmPBrcBottom80: return setMeta('para', 'borderBottom', parseBrc80(bytes, 0), raw, bytes);
+    case SprmCodes.sprmPBrcBottom: return setMeta('para', 'borderBottom', parseBrc(bytes, 1), raw, bytes);
+    case SprmCodes.sprmPBrcRight80: return setMeta('para', 'borderRight', parseBrc80(bytes, 0), raw, bytes);
+    case SprmCodes.sprmPBrcRight: return setMeta('para', 'borderRight', parseBrc(bytes, 1), raw, bytes);
+    case SprmCodes.sprmPBrcBetween80: return setMeta('para', 'borderBetween', parseBrc80(bytes, 0), raw, bytes);
+    case SprmCodes.sprmPBrcBetween: return setMeta('para', 'borderBetween', parseBrc(bytes, 1), raw, bytes);
+    case SprmCodes.sprmPBrcBar80: return setMeta('para', 'borderBar', parseBrc80(bytes, 0), raw, bytes);
+    case SprmCodes.sprmPBrcBar: return setMeta('para', 'borderBar', parseBrc(bytes, 1), raw, bytes);
     case SprmCodes.sprmPWHeightAbs: return setMeta('para', 'frameHeight', i16(bytes, 0), raw, bytes);
     case SprmCodes.sprmPShd80:
     case SprmCodes.sprmPShd: return setMeta('para', 'shading', bytes.slice(), raw, bytes);
@@ -471,6 +604,15 @@ export function decodeSprm(sprm: number, operandBytes: Uint8Array): DecodedPrope
     case SprmCodes.sprmTTableHeader: return setMeta('table', 'header', boolValue(bytes), raw, bytes);
     case SprmCodes.sprmTDyaRowHeight: return setMeta('table', 'rowHeight', i16(bytes, 0), raw, bytes);
     case SprmCodes.sprmTDefTable: return setMeta('table', 'defTable', parseTDefTableOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTTableBorders80: return setMeta('table', 'tableBorders', parseTableBorders(bytes, true), raw, bytes);
+    case SprmCodes.sprmTTableBorders: return setMeta('table', 'tableBorders', parseTableBorders(bytes, false), raw, bytes);
+    case SprmCodes.sprmTDefTableShd80: return setMeta('table', 'defaultShading', parseDefaultShading(bytes, 0, true), raw, bytes);
+    case SprmCodes.sprmTDefTableShd:
+    case SprmCodes.sprmTDefTableShdRaw: return setMeta('table', 'defaultShading', parseDefaultShading(bytes, 0, false), raw, bytes);
+    case SprmCodes.sprmTDefTableShd2nd:
+    case SprmCodes.sprmTDefTableShdRaw2nd: return setMeta('table', 'defaultShading', parseDefaultShading(bytes, 22, false), raw, bytes);
+    case SprmCodes.sprmTDefTableShd3rd:
+    case SprmCodes.sprmTDefTableShdRaw3rd: return setMeta('table', 'defaultShading', parseDefaultShading(bytes, 44, false), raw, bytes);
     case SprmCodes.sprmTFBiDi: return setMeta('table', 'rtl', boolValue(bytes), raw, bytes);
     case SprmCodes.sprmTPc: return setMeta('table', 'positionCode', bytes[0] ?? 0, raw, bytes);
     case SprmCodes.sprmTDxaAbs: return setMeta('table', 'absLeft', i16(bytes, 0), raw, bytes);
@@ -483,20 +625,24 @@ export function decodeSprm(sprm: number, operandBytes: Uint8Array): DecodedPrope
     case SprmCodes.sprmTWidthAfter: return setMeta('table', 'widthAfter', parseTTableWidth(bytes), raw, bytes);
     case SprmCodes.sprmTInsert: return setMeta('table', 'insertCells', parseTInsertOperand(bytes), raw, bytes);
     case SprmCodes.sprmTDelete: return setMeta('table', 'deleteCells', parseItcFirstLim(bytes, 0), raw, bytes);
-    case SprmCodes.sprmTDxaCol: return setMeta('table', 'columnWidth', parseRangeWidthOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTDxaCol: return setMeta('table', 'columnWidth', parseFixedRangeWidthOperand(bytes), raw, bytes);
     case SprmCodes.sprmTMerge: return setMeta('table', 'merge', parseItcFirstLim(bytes, 0), raw, bytes);
     case SprmCodes.sprmTSplit: return setMeta('table', 'split', parseItcFirstLim(bytes, 0), raw, bytes);
-    case SprmCodes.sprmTTextFlow: return setMeta('table', 'textFlow', parseRangeValueOperand(bytes), raw, bytes);
-    case SprmCodes.sprmTVertMerge: return setMeta('table', 'vertMerge', parseRangeValueOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTTextFlow: return setMeta('table', 'textFlow', {
+      range: parseItcFirstLim(bytes, 0),
+      value: u16(bytes, 2),
+    }, raw, bytes);
+    case SprmCodes.sprmTVertMerge: return setMeta('table', 'vertMerge', parseVertMergeOperand(bytes), raw, bytes);
     case SprmCodes.sprmTVertAlign: return setMeta('table', 'vertAlign', parseRangeValueOperand(bytes), raw, bytes);
-    case SprmCodes.sprmTSetShd:
-    case SprmCodes.sprmTSetShdOdd: return setMeta('table', 'setShading', parseRangeValueOperand(bytes), raw, bytes);
-    case SprmCodes.sprmTSetBrc80:
-    case SprmCodes.sprmTSetBrc: return setMeta('table', 'setBorder', parseRangeBrcOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTSetShd: return setMeta('table', 'setShading', parseTableShadeOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTSetShdOdd: return setMeta('table', 'setShading', parseTableShadeOperand(bytes, true), raw, bytes);
+    case SprmCodes.sprmTSetBrc80: return setMeta('table', 'setBorder', parseRangeBrcOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTSetBrc: return setMeta('table', 'setBorder', parseRangeBrcOperand97(bytes), raw, bytes);
     case SprmCodes.sprmTCellPadding:
-    case SprmCodes.sprmTCellPaddingDefault: return setMeta('table', 'cellPadding', parseRangeWidthOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTCellPaddingDefault: return setMeta('table', 'cellPadding', parseCssaOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTCellSpacingDefault: return setMeta('table', 'cellSpacing', parseCssaOperand(bytes), raw, bytes);
     case SprmCodes.sprmTCellWidth: return setMeta('table', 'cellWidth', parseRangeWidthOperand(bytes), raw, bytes);
-    case SprmCodes.sprmTFitText: return setMeta('table', 'fitText', parseRangeValueOperand(bytes), raw, bytes);
+    case SprmCodes.sprmTFitText: return setMeta('table', 'fitText', parseFixedRangeValueOperand(bytes), raw, bytes);
     case SprmCodes.sprmTFCellNoWrap: return setMeta('table', 'cellNoWrap', parseRangeValueOperand(bytes), raw, bytes);
     case SprmCodes.sprmTIstd: return setMeta('table', 'styleId', u16(bytes, 0), raw, bytes);
     default: {

--- a/packages/renderers/doc/src/msdoc/styles.ts
+++ b/packages/renderers/doc/src/msdoc/styles.ts
@@ -10,11 +10,32 @@ import type {
   StyleDefinition,
 } from '../types.js';
 
+const REPEATABLE_TABLE_PROPERTIES = new Set([
+  'insertCells',
+  'deleteCells',
+  'columnWidth',
+  'merge',
+  'split',
+  'textFlow',
+  'vertMerge',
+  'vertAlign',
+  'setShading',
+  'defaultShading',
+  'setBorder',
+  'cellPadding',
+  'cellSpacing',
+  'cellWidth',
+  'fitText',
+  'cellNoWrap',
+]);
+
 function mergePropertyArrays(...arrays: Array<DecodedProperty[] | undefined | null>): DecodedProperty[] {
   const map = new Map<string, DecodedProperty>();
+  let sequence = 0;
   for (const array of arrays) {
     for (const prop of array || []) {
-      map.set(`${prop.kind}:${prop.name}`, prop);
+      const repeatable = prop.kind === 'table' && REPEATABLE_TABLE_PROPERTIES.has(prop.name);
+      map.set(repeatable ? `${prop.kind}:${prop.name}:${sequence++}` : `${prop.kind}:${prop.name}`, prop);
     }
   }
   return Array.from(map.values());

--- a/packages/renderers/doc/src/render/html.ts
+++ b/packages/renderers/doc/src/render/html.ts
@@ -15,6 +15,7 @@ import type {
   ParagraphBlock,
   TableBlock,
   TableCellBlock,
+  ShadingSpec,
   TextInlineNode,
 } from '../types.js';
 
@@ -45,13 +46,72 @@ function styleObjectToCss(style: CssStyleObject): string {
 }
 
 function borderToCss(border: BorderSpec | undefined | null): string | null {
-  if (!border) return null;
-  const width = Math.max(1, Math.round((((border.lineWidth as number | undefined) ?? 8) / 8) * 1.3333));
+  if (!border || border.nil) return null;
   const borderType = border.borderType as number | undefined;
-  const style = borderType === 6 ? 'double' : borderType === 3 ? 'dotted' : borderType === 2 ? 'dashed' : 'solid';
+  if (!borderType) return null;
+  const lineWidth = Math.max(2, border.lineWidth || 0);
+  const widthPoints = borderType >= 0x40 ? lineWidth : lineWidth / 8;
+  const width = Math.max(1, Math.round(widthPoints * (96 / 72)));
+  const style = borderType === 3
+    ? 'double'
+    : borderType === 6
+      ? 'dotted'
+      : [7, 8, 9].includes(borderType)
+        ? 'dashed'
+        : 'solid';
   const colorIndex = border.color as number | undefined;
-  const color = colorIndex ? COLOR_INDEX_MAP[colorIndex] || '#666' : '#666';
+  const color = border.colorRef != null
+    ? colorRefToCss(border.colorRef)
+    : COLOR_INDEX_MAP[colorIndex || 1] || '#000000';
   return `${width}px ${style} ${color}`;
+}
+
+function colorRefToCss(colorRef: number | undefined): string {
+  if (colorRef == null || (colorRef >>> 24) === 0xff) return '#000000';
+  const red = colorRef & 0xff;
+  const green = (colorRef >>> 8) & 0xff;
+  const blue = (colorRef >>> 16) & 0xff;
+  return `#${[red, green, blue].map(value => value.toString(16).padStart(2, '0')).join('')}`;
+}
+
+const SHADING_PERCENT: Record<number, number> = {
+  2: 5, 3: 10, 4: 20, 5: 25, 6: 30, 7: 40,
+  8: 50, 9: 60, 10: 70, 11: 75, 12: 80, 13: 90,
+};
+
+function mixHexColors(foreground: string, background: string, percent: number): string {
+  const channel = (color: string, offset: number) => Number.parseInt(color.slice(offset, offset + 2), 16);
+  const ratio = Math.max(0, Math.min(100, percent)) / 100;
+  const values = [1, 3, 5].map(offset => Math.round(
+    channel(foreground, offset) * ratio + channel(background, offset) * (1 - ratio)
+  ));
+  return `#${values.map(value => value.toString(16).padStart(2, '0')).join('')}`;
+}
+
+function shadingToCss(shading: ShadingSpec | undefined): CssStyleObject {
+  if (!shading || shading.nil || shading.auto || shading.pattern === 0) return {};
+  const foreground = shading.foregroundColorRef != null
+    ? colorRefToCss(shading.foregroundColorRef)
+    : COLOR_INDEX_MAP[shading.foregroundColorIndex || 1] || '#000000';
+  const background = shading.backgroundColorRef != null
+    ? colorRefToCss(shading.backgroundColorRef)
+    : COLOR_INDEX_MAP[shading.backgroundColorIndex || 8] || '#ffffff';
+  if (shading.pattern === 1) return { 'background-color': foreground };
+  if (SHADING_PERCENT[shading.pattern] != null) {
+    return { 'background-color': mixHexColors(foreground, background, SHADING_PERCENT[shading.pattern]!) };
+  }
+  const stripe = shading.pattern === 14 || shading.pattern === 20
+    ? `repeating-linear-gradient(0deg,${foreground} 0 1px,transparent 1px 4px)`
+    : shading.pattern === 15 || shading.pattern === 21
+      ? `repeating-linear-gradient(90deg,${foreground} 0 1px,transparent 1px 4px)`
+      : shading.pattern === 16 || shading.pattern === 22
+        ? `repeating-linear-gradient(45deg,${foreground} 0 1px,transparent 1px 5px)`
+        : shading.pattern === 17 || shading.pattern === 23
+          ? `repeating-linear-gradient(-45deg,${foreground} 0 1px,transparent 1px 5px)`
+          : null;
+  return stripe
+    ? { 'background-color': background, 'background-image': stripe }
+    : { 'background-color': background };
 }
 
 function paragraphStyleToCss(paraState: ParagraphBlock['paraState']): CssStyleObject {
@@ -82,9 +142,9 @@ function paragraphStyleToCss(paraState: ParagraphBlock['paraState']): CssStyleOb
   const bottom = borderToCss(paraState.borders?.bottom);
   const left = borderToCss(paraState.borders?.left);
   if (top) style['border-top'] = top;
-  if (right) style['border-right'] = right;
+  if (right) style['border-inline-end'] = right;
   if (bottom) style['border-bottom'] = bottom;
-  if (left) style['border-left'] = left;
+  if (left) style['border-inline-start'] = left;
   return style;
 }
 
@@ -245,21 +305,25 @@ function cellStyle(cell: TableCellBlock): CssStyleObject {
   if (cell.meta?.noWrap) style['white-space'] = 'nowrap';
   if (cell.meta?.fitText) style['text-align'] = 'justify';
   if (cell.meta?.vertAlign != null) style['vertical-align'] = cssVerticalAlign(cell.meta.vertAlign);
-  const borderAll = borderToCss(cell.meta?.borders?.all);
-  const top = borderToCss(cell.meta?.borders?.top) || borderAll;
-  const right = borderToCss(cell.meta?.borders?.right) || borderAll;
-  const bottom = borderToCss(cell.meta?.borders?.bottom) || borderAll;
-  const left = borderToCss(cell.meta?.borders?.left) || borderAll;
+  const borders = cell.meta?.borders || {};
+  const borderAll = borderToCss(borders.all);
+  const borderForSide = (side: string) => Object.prototype.hasOwnProperty.call(borders, side)
+    ? borderToCss(borders[side])
+    : borderAll;
+  const top = borderForSide('top');
+  const right = borderForSide('right');
+  const bottom = borderForSide('bottom');
+  const left = borderForSide('left');
   if (top) style['border-top'] = top;
-  if (right) style['border-right'] = right;
+  if (right) style['border-inline-end'] = right;
   if (bottom) style['border-bottom'] = bottom;
-  if (left) style['border-left'] = left;
-  const shadingColor = typeof cell.meta?.shading === 'object' && cell.meta?.shading && 'color' in (cell.meta.shading as Record<string, unknown>)
-    ? (cell.meta.shading as { color?: number }).color
-    : undefined;
-  if (shadingColor && COLOR_INDEX_MAP[shadingColor]) {
-    style['background-color'] = COLOR_INDEX_MAP[shadingColor];
-  }
+  if (left) style['border-inline-start'] = left;
+  const padding = cell.meta?.paddingTwips;
+  if (padding?.top != null) style['padding-top'] = `${twipsToPx(padding.top)}px`;
+  if (padding?.right != null) style['padding-inline-end'] = `${twipsToPx(padding.right)}px`;
+  if (padding?.bottom != null) style['padding-bottom'] = `${twipsToPx(padding.bottom)}px`;
+  if (padding?.left != null) style['padding-inline-start'] = `${twipsToPx(padding.left)}px`;
+  Object.assign(style, shadingToCss(cell.meta?.shading));
   return style;
 }
 
@@ -269,8 +333,22 @@ function tableStyle(block: TableBlock): CssStyleObject {
   if (widthPx) style.width = `${widthPx}px`;
   else style.width = '100%';
   const marginLeft = twipsToPx(block.state?.leftIndent);
-  if (marginLeft) style['margin-left'] = `${marginLeft}px`;
-  style['border-collapse'] = 'collapse';
+  if (marginLeft) style['margin-inline-start'] = `${marginLeft}px`;
+  if (block.state?.rtl) style.direction = 'rtl';
+  const spacing = block.rows.flatMap(row => row.cells).reduce((maximum, cell) => {
+    const value = cell.meta?.spacingTwips;
+    if (!value) return maximum;
+    return {
+      horizontal: Math.max(maximum.horizontal, value.left || 0, value.right || 0),
+      vertical: Math.max(maximum.vertical, value.top || 0, value.bottom || 0),
+    };
+  }, { horizontal: 0, vertical: 0 });
+  if (spacing.horizontal || spacing.vertical) {
+    style['border-collapse'] = 'separate';
+    style['border-spacing'] = `${twipsToPx(spacing.horizontal)}px ${twipsToPx(spacing.vertical)}px`;
+  } else {
+    style['border-collapse'] = 'collapse';
+  }
   style['table-layout'] = 'fixed';
   return style;
 }

--- a/packages/renderers/doc/src/types.ts
+++ b/packages/renderers/doc/src/types.ts
@@ -223,7 +223,32 @@ export interface BorderSpec {
   borderType?: number;
   lineWidth?: number;
   color?: number;
+  colorRef?: number;
+  frame?: boolean;
+  nil?: boolean;
+  shadow?: boolean;
+  space?: number;
   [key: string]: unknown;
+}
+
+export interface TableBorders {
+  top?: BorderSpec;
+  left?: BorderSpec;
+  bottom?: BorderSpec;
+  right?: BorderSpec;
+  horizontalInside?: BorderSpec;
+  verticalInside?: BorderSpec;
+}
+
+export interface ShadingSpec {
+  foregroundColorIndex?: number;
+  backgroundColorIndex?: number;
+  foregroundColorRef?: number;
+  backgroundColorRef?: number;
+  pattern: number;
+  auto?: boolean;
+  nil?: boolean;
+  legacy?: boolean;
 }
 
 export interface HighlightInfo {
@@ -348,6 +373,7 @@ export interface ItcRange {
 export interface RangeWidthOperand {
   cb?: number;
   range: ItcRange;
+  sides?: number;
   width?: number;
   wWidth?: number;
   ftsWidth?: number;
@@ -357,6 +383,7 @@ export interface RangeBorderOperand {
   cb?: number;
   range: ItcRange;
   border: BorderSpec;
+  bordersToApply: number;
   extra?: Uint8Array;
 }
 
@@ -374,13 +401,9 @@ export interface TableWidthOperand {
 }
 
 export interface TInsertOperand {
-  cb?: number;
-  range?: ItcRange;
   itcFirst?: number;
-  dxaCol?: number[] | number;
-  dxaGapHalf?: number;
   ctc?: number;
-  cells?: unknown[];
+  dxaCol?: number;
   [key: string]: unknown;
 }
 
@@ -402,6 +425,7 @@ export interface TableState {
   autoFit?: unknown;
   widthBefore?: unknown;
   widthAfter?: unknown;
+  borders: TableBorders;
   defTable?: TDefTableOperand;
   operations: DecodedProperty[];
   [key: string]: unknown;
@@ -421,7 +445,9 @@ export interface TableCellMeta {
   textFlow?: number;
   rightBoundary?: number;
   leftBoundary?: number;
-  shading?: unknown;
+  shading?: ShadingSpec;
+  paddingTwips?: Partial<Record<'top' | 'left' | 'bottom' | 'right', number>>;
+  spacingTwips?: Partial<Record<'top' | 'left' | 'bottom' | 'right', number>>;
 }
 
 export interface CharSegment {

--- a/packages/renderers/doc/test/browser-table-smoke.html
+++ b/packages/renderers/doc/test/browser-table-smoke.html
@@ -1,0 +1,9 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width,initial-scale=1" /></head>
+  <body>
+    <pre data-testid="result">pending</pre>
+    <div data-testid="viewer" style="width:1000px;height:760px;overflow:auto;background:#eef1f4"></div>
+    <script type="module" src="./browser-table-smoke.ts"></script>
+  </body>
+</html>

--- a/packages/renderers/doc/test/browser-table-smoke.ts
+++ b/packages/renderers/doc/test/browser-table-smoke.ts
@@ -1,0 +1,50 @@
+import { createViewer } from '../../../core/src/index.ts';
+import wordRenderer from '../../word/src/index.js';
+
+const output = document.querySelector('[data-testid="result"]') as HTMLElement;
+const host = document.querySelector('[data-testid="viewer"]') as HTMLDivElement;
+
+try {
+  const response = await fetch('./fixtures/github-34-wps-table.doc');
+  if (!response.ok) throw new Error(`Fixture request failed with HTTP ${response.status}.`);
+  const viewer = createViewer(host, { options: { renderers: [wordRenderer] } });
+  await viewer.load({
+    buffer: await response.arrayBuffer(),
+    filename: 'github-34-wps-table.doc',
+    type: 'doc',
+  });
+
+  const tables = host.querySelectorAll('.msdoc-table');
+  const rows = host.querySelectorAll('.msdoc-row');
+  const cells = host.querySelectorAll('.msdoc-cell');
+  const text = host.textContent || '';
+  const syntheticGrayBorder = Array.from(cells).some(cell =>
+    (cell.getAttribute('style') || '').includes('#666')
+  );
+  const firstCellStyle = cells[0] ? getComputedStyle(cells[0]) : null;
+  const lastCellStyle = cells[cells.length - 1] ? getComputedStyle(cells[cells.length - 1]) : null;
+  const outerBorderVisible = firstCellStyle?.borderTopStyle === 'solid' &&
+    firstCellStyle.borderInlineStartStyle === 'solid' &&
+    lastCellStyle?.borderBottomStyle === 'solid' &&
+    lastCellStyle.borderInlineEndStyle === 'solid';
+  const passed = tables.length === 1 && rows.length === 16 && cells.length === 80 &&
+    text.includes('测试组分A') && !syntheticGrayBorder && outerBorderVisible;
+  output.dataset.status = passed ? 'passed' : 'failed';
+  output.textContent = JSON.stringify({
+    passed,
+    tables: tables.length,
+    rows: rows.length,
+    cells: cells.length,
+    syntheticGrayBorder,
+    outerBorderVisible,
+  }, null, 2);
+  const visualSnapshot = host.cloneNode(true);
+  await viewer.destroy();
+  host.replaceWith(visualSnapshot);
+} catch (error) {
+  output.dataset.status = 'failed';
+  output.textContent = JSON.stringify({
+    passed: false,
+    error: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+  }, null, 2);
+}


### PR DESCRIPTION
## Summary
- fix MS-DOC table borders, merges, widths, shading, padding, and spacing
- add focused table regression coverage
- keep demo controls visible and move integration code into an accessible, copyable modal

## Validation
- DOC TypeScript build and table spec regression
- GitHub #34 and #87 DOC fixtures
- demo type-check and production build
- desktop and mobile browser regression
