### PR TITLE
Fix Shapefile previews in archives

### DIFF
--- a/packages/renderers/archive/package.json
+++ b/packages/renderers/archive/package.json
@@ -58,7 +58,8 @@
   "scripts": {
     "build": "tsc -b tsconfig.json",
     "type-check": "tsc -b tsconfig.json",
-    "verify:github-101": "pnpm build && node scripts/verify-github-101.mjs"
+    "verify:github-101": "pnpm build && node scripts/verify-github-101.mjs",
+    "verify:github-148": "pnpm build && node scripts/verify-github-148.mjs"
   },
   "dependencies": {
     "@file-viewer/core": "workspace:2.2.3",

--- a/packages/renderers/archive/scripts/verify-github-148.mjs
+++ b/packages/renderers/archive/scripts/verify-github-148.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import JSZip from 'jszip';
+import {
+  createShapefileBundleArchive,
+  getShapefileBundleEntries,
+} from '../dist/shapefileBundle.js';
+
+const encoder = new TextEncoder();
+const entry = (path, content) => {
+  const filename = path.split('/').pop();
+  const extension = filename.split('.').pop().toLowerCase();
+  const buffer = encoder.encode(content).buffer;
+  return {
+    id: path,
+    path,
+    name: filename,
+    extension,
+    size: buffer.byteLength,
+    depth: path.split('/').length - 1,
+    previewable: extension === 'shp',
+    compressedFile: {
+      name: filename,
+      size: buffer.byteLength,
+      async extract() {
+        return new File([buffer], filename);
+      },
+    },
+    buffer,
+  };
+};
+
+const selected = entry('maps/Vegetation.SHP', 'shape');
+const dbf = entry('maps/vegetation.dbf', 'attributes');
+const projection = entry('maps/VEGETATION.prj', 'projection');
+const encoding = entry('maps/vegetation.CPG', 'UTF-8');
+const index = entry('maps/vegetation.shx', 'index');
+const metadata = entry('maps/vegetation.shp.xml', 'metadata');
+const otherDirectory = entry('backup/vegetation.dbf', 'wrong directory');
+const otherDataset = entry('maps/roads.dbf', 'wrong dataset');
+const entries = [
+  otherDataset,
+  projection,
+  metadata,
+  selected,
+  otherDirectory,
+  index,
+  dbf,
+  encoding,
+];
+
+const bundleEntries = getShapefileBundleEntries(entries, selected);
+assert.deepEqual(
+  bundleEntries.map(item => item.path),
+  [
+    'maps/Vegetation.SHP',
+    'maps/vegetation.dbf',
+    'maps/vegetation.shx',
+    'maps/VEGETATION.prj',
+    'maps/vegetation.CPG',
+  ]
+);
+assert.deepEqual(getShapefileBundleEntries(entries, metadata), []);
+
+const bundle = await createShapefileBundleArchive(
+  bundleEntries,
+  async item => item.buffer
+);
+const zip = await JSZip.loadAsync(bundle);
+assert.deepEqual(
+  Object.keys(zip.files),
+  [
+    'Vegetation.SHP',
+    'vegetation.dbf',
+    'vegetation.shx',
+    'VEGETATION.prj',
+    'vegetation.CPG',
+  ]
+);
+assert.equal(await zip.file('vegetation.dbf').async('string'), 'attributes');
+assert.equal(await zip.file('VEGETATION.prj').async('string'), 'projection');
+
+console.log('Issue #148 Shapefile archive bundling verified.');

--- a/packages/renderers/archive/src/archive.ts
+++ b/packages/renderers/archive/src/archive.ts
@@ -44,6 +44,10 @@ import {
   comicBookStyle,
   createComicBookController,
 } from './comicBook.js';
+import {
+  createShapefileBundleArchive,
+  getShapefileBundleEntries,
+} from './shapefileBundle.js';
 
 type WorkerConstructor = new (scriptURL: string | URL, options?: WorkerOptions) => Worker;
 type FileConstructor = new (fileBits: BlobPart[], fileName: string, options?: FilePropertyBag) => File;
@@ -1055,10 +1059,14 @@ export default async function renderArchive(
     comicBook.onEntrySelected(entry);
     renderEntryList();
     syncState();
-    if (entry.size > maxEntryPreviewSize) {
+    const shapefileEntries = getShapefileBundleEntries(entries, entry);
+    const previewSize = shapefileEntries.length
+      ? shapefileEntries.reduce((sum, component) => sum + component.size, 0)
+      : entry.size;
+    if (previewSize > maxEntryPreviewSize) {
       setError(t('archive.error.entryTooLarge', {
         name: entry.name,
-        size: formatArchiveBytes(entry.size),
+        size: formatArchiveBytes(previewSize),
         limit: formatArchiveBytes(maxEntryPreviewSize),
       }));
       return;
@@ -1068,7 +1076,9 @@ export default async function renderArchive(
     setError('');
 
     try {
-      const entryBuffer = await extractEntryBuffer(entry);
+      const entryBuffer = shapefileEntries.length
+        ? await createShapefileBundleArchive(shapefileEntries, extractEntryBuffer)
+        : await extractEntryBuffer(entry);
       if (requestId !== previewSequence) {
         return;
       }

--- a/packages/renderers/archive/src/shapefileBundle.ts
+++ b/packages/renderers/archive/src/shapefileBundle.ts
@@ -1,0 +1,131 @@
+import {
+  getArchiveEntryExtension,
+  type ArchiveEntryView,
+} from './archiveShared.js';
+
+const SHAPEFILE_COMPONENT_EXTENSIONS = new Set([
+  'shp',
+  'shx',
+  'dbf',
+  'prj',
+  'cpg',
+]);
+
+const SHAPEFILE_COMPONENT_ORDER = new Map([
+  ['shp', 0],
+  ['dbf', 1],
+  ['shx', 2],
+  ['prj', 3],
+  ['cpg', 4],
+]);
+
+interface ArchivePathParts {
+  directory: string;
+  filename: string;
+  stem: string;
+  extension: string;
+}
+
+type JSZipWriter = {
+  file(name: string, data: ArrayBuffer): JSZipWriter;
+  generateAsync(options: {
+    type: 'arraybuffer';
+    compression: 'STORE';
+  }): Promise<ArrayBuffer>;
+};
+
+type JSZipWriterConstructor = new () => JSZipWriter;
+
+const normalizeArchivePath = (path: string) => path
+  .replace(/^\/+/, '')
+  .replace(/\\/g, '/');
+
+const getArchivePathParts = (path: string): ArchivePathParts => {
+  const normalized = normalizeArchivePath(path);
+  const slash = normalized.lastIndexOf('/');
+  const directory = slash === -1 ? '' : normalized.slice(0, slash);
+  const filename = slash === -1 ? normalized : normalized.slice(slash + 1);
+  const extension = getArchiveEntryExtension(filename);
+  const stem = extension
+    ? filename.slice(0, -(extension.length + 1))
+    : filename;
+
+  return {
+    directory: directory.toLowerCase(),
+    filename,
+    stem: stem.toLowerCase(),
+    extension,
+  };
+};
+
+const resolveJSZipWriter = (module: unknown): JSZipWriterConstructor => {
+  const record = module as Record<string, unknown> | undefined;
+  const defaultRecord = record?.default as Record<string, unknown> | undefined;
+  const candidates = [
+    record?.default,
+    defaultRecord?.default,
+    record?.JSZip,
+    module,
+  ];
+  const constructor = candidates.find(candidate => typeof candidate === 'function');
+
+  if (!constructor) {
+    throw new Error('JSZip module does not expose a constructor.');
+  }
+  return constructor as JSZipWriterConstructor;
+};
+
+/**
+ * Finds the files that form the selected Shapefile dataset. Shapefile
+ * sidecars are matched case-insensitively by directory and basename so an
+ * archive containing multiple datasets never leaks attributes or projection
+ * metadata from a neighbouring dataset into the preview.
+ */
+export const getShapefileBundleEntries = (
+  entries: readonly ArchiveEntryView[],
+  selectedEntry: ArchiveEntryView
+) => {
+  const selected = getArchivePathParts(selectedEntry.path);
+  if (selected.extension !== 'shp') {
+    return [];
+  }
+
+  return entries
+    .filter(entry => {
+      const candidate = getArchivePathParts(entry.path);
+      return candidate.directory === selected.directory &&
+        candidate.stem === selected.stem &&
+        SHAPEFILE_COMPONENT_EXTENSIONS.has(candidate.extension);
+    })
+    .sort((left, right) => {
+      const leftExtension = getArchivePathParts(left.path).extension;
+      const rightExtension = getArchivePathParts(right.path).extension;
+      return (SHAPEFILE_COMPONENT_ORDER.get(leftExtension) ?? Number.MAX_SAFE_INTEGER) -
+        (SHAPEFILE_COMPONENT_ORDER.get(rightExtension) ?? Number.MAX_SAFE_INTEGER);
+    });
+};
+
+/**
+ * shpjs accepts an ArrayBuffer ZIP for a complete Shapefile dataset. Archive
+ * previews normally extract one entry at a time, so rebuild a small STORE-only
+ * ZIP from the selected .shp and its sidecars before delegating to the existing
+ * geospatial renderer. STORE avoids wasting CPU recompressing already
+ * compressed archive data.
+ */
+export const createShapefileBundleArchive = async (
+  entries: readonly ArchiveEntryView[],
+  readEntry: (entry: ArchiveEntryView) => Promise<ArrayBuffer>
+) => {
+  const JSZip = resolveJSZipWriter(await import('jszip'));
+  const zip = new JSZip();
+
+  for (const entry of entries) {
+    const { filename } = getArchivePathParts(entry.path);
+    zip.file(filename || entry.name, await readEntry(entry));
+  }
+
+  return zip.generateAsync({
+    type: 'arraybuffer',
+    compression: 'STORE',
+  });
+};


### PR DESCRIPTION
## Summary

- detect the Shapefile dataset selected inside an archive and collect only its matching sidecar files
- rebuild those components as a lightweight ZIP before delegating to the existing shpjs geo renderer
- add a focused regression for Issue #148 without changing normal archive previews

## Validation

- Issue #148 and existing Issue #101 archive regressions
- original `ddd.zip`: 1,318 features rendered successfully with MapLibre
- all renderer and preset builds
- demo type-check, production build, and browser upload regression

Fixes #148
