### PR TITLE
Fix missing DOCX page layout defaults

### DIFF
--- a/packages/renderers/word/package.json
+++ b/packages/renderers/word/package.json
@@ -58,7 +58,8 @@
   ],
   "scripts": {
     "build": "tsc -b tsconfig.json",
-    "type-check": "tsc -b tsconfig.json"
+    "type-check": "tsc -b tsconfig.json",
+    "verify:page-defaults": "pnpm build && node scripts/verify-docx-page-defaults.mjs"
   },
   "dependencies": {
     "@file-viewer/core": "workspace:2.2.3",
@@ -68,6 +69,7 @@
     "rtf.js": "^3.0.9"
   },
   "devDependencies": {
+    "@xmldom/xmldom": "0.9.10",
     "typescript": "^6.0.3"
   },
   "license": "Apache-2.0"

--- a/packages/renderers/word/scripts/verify-docx-page-defaults.mjs
+++ b/packages/renderers/word/scripts/verify-docx-page-defaults.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+import JSZip from 'jszip';
+import {
+  DOCX_DEFAULT_PAGE_LAYOUT,
+  normalizeDocxPageLayout
+} from '../dist/docxPageDefaults.js';
+
+const WORD_NAMESPACE =
+  'http://schemas.openxmlformats.org/wordprocessingml/2006/main';
+const runtime = {
+  parse: (xml) => new DOMParser().parseFromString(xml, 'application/xml'),
+  serialize: (document) => new XMLSerializer().serializeToString(document)
+};
+
+const wrapDocument = (
+  body
+) => `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="${WORD_NAMESPACE}"><w:body>${body}</w:body></w:document>`;
+
+const createPackage = async (documentXml) => {
+  const zip = new JSZip();
+  zip.file('word/document.xml', documentXml);
+  return zip.generateAsync({ type: 'arraybuffer' });
+};
+
+const readDocument = async (buffer) => {
+  const zip = await JSZip.loadAsync(buffer);
+  return runtime.parse(await zip.file('word/document.xml').async('string'));
+};
+
+const children = (element) =>
+  Array.from(element.childNodes).filter((node) => node.nodeType === 1);
+const first = (document, name) =>
+  document.getElementsByTagNameNS(WORD_NAMESPACE, name)[0];
+const attribute = (element, name) =>
+  element.getAttributeNS(WORD_NAMESPACE, name);
+
+const missingSectionPackage = await createPackage(
+  wrapDocument('<w:p><w:r><w:t>content</w:t></w:r></w:p>')
+);
+const normalizedMissingSection = await normalizeDocxPageLayout(
+  missingSectionPackage,
+  runtime
+);
+const missingSectionDocument = await readDocument(normalizedMissingSection);
+const createdSection = first(missingSectionDocument, 'sectPr');
+const createdPageSize = first(missingSectionDocument, 'pgSz');
+const createdMargins = first(missingSectionDocument, 'pgMar');
+
+assert.ok(createdSection);
+assert.equal(attribute(createdPageSize, 'w'), DOCX_DEFAULT_PAGE_LAYOUT.width);
+assert.equal(attribute(createdPageSize, 'h'), DOCX_DEFAULT_PAGE_LAYOUT.height);
+assert.equal(
+  attribute(createdMargins, 'top'),
+  DOCX_DEFAULT_PAGE_LAYOUT.marginTop
+);
+assert.equal(
+  attribute(createdMargins, 'right'),
+  DOCX_DEFAULT_PAGE_LAYOUT.marginRight
+);
+assert.equal(
+  attribute(createdMargins, 'bottom'),
+  DOCX_DEFAULT_PAGE_LAYOUT.marginBottom
+);
+assert.equal(
+  attribute(createdMargins, 'left'),
+  DOCX_DEFAULT_PAGE_LAYOUT.marginLeft
+);
+assert.equal(
+  attribute(createdMargins, 'header'),
+  DOCX_DEFAULT_PAGE_LAYOUT.header
+);
+assert.equal(
+  attribute(createdMargins, 'footer'),
+  DOCX_DEFAULT_PAGE_LAYOUT.footer
+);
+assert.equal(
+  attribute(createdMargins, 'gutter'),
+  DOCX_DEFAULT_PAGE_LAYOUT.gutter
+);
+
+const partialPackage = await createPackage(
+  wrapDocument(`
+  <w:p><w:pPr><w:sectPr>
+    <w:pgSz w:orient="landscape"/>
+    <w:pgMar w:top="0"/>
+    <w:cols w:num="1"/>
+  </w:sectPr></w:pPr></w:p>
+  <w:sectPr>
+    <w:pgSz w:w="10000" w:h="20000"/>
+    <w:pgMar w:top="100" w:right="200" w:bottom="300" w:left="400" w:header="500" w:footer="600" w:gutter="700"/>
+  </w:sectPr>
+`)
+);
+const normalizedPartial = await normalizeDocxPageLayout(
+  partialPackage,
+  runtime
+);
+const partialDocument = await readDocument(normalizedPartial);
+const partialSections = Array.from(
+  partialDocument.getElementsByTagNameNS(WORD_NAMESPACE, 'sectPr')
+);
+const firstPageSize = children(partialSections[0]).find(
+  (node) => node.localName === 'pgSz'
+);
+const firstMargins = children(partialSections[0]).find(
+  (node) => node.localName === 'pgMar'
+);
+const orderedNames = children(partialSections[0]).map((node) => node.localName);
+
+assert.equal(attribute(firstPageSize, 'w'), DOCX_DEFAULT_PAGE_LAYOUT.height);
+assert.equal(attribute(firstPageSize, 'h'), DOCX_DEFAULT_PAGE_LAYOUT.width);
+assert.equal(attribute(firstMargins, 'top'), '0');
+assert.equal(
+  attribute(firstMargins, 'left'),
+  DOCX_DEFAULT_PAGE_LAYOUT.marginLeft
+);
+assert.ok(orderedNames.indexOf('pgSz') < orderedNames.indexOf('pgMar'));
+assert.ok(orderedNames.indexOf('pgMar') < orderedNames.indexOf('cols'));
+
+const finalPageSize = children(partialSections[1]).find(
+  (node) => node.localName === 'pgSz'
+);
+const finalMargins = children(partialSections[1]).find(
+  (node) => node.localName === 'pgMar'
+);
+assert.equal(attribute(finalPageSize, 'w'), '10000');
+assert.equal(attribute(finalPageSize, 'h'), '20000');
+assert.equal(attribute(finalMargins, 'left'), '400');
+assert.equal(attribute(finalMargins, 'gutter'), '700');
+
+const completePackage = await createPackage(
+  wrapDocument(`
+  <w:p/>
+  <w:sectPr>
+    <w:pgSz w:w="10000" w:h="20000"/>
+    <w:pgMar w:top="0" w:right="0" w:bottom="0" w:left="0" w:header="0" w:footer="0" w:gutter="0"/>
+  </w:sectPr>
+`)
+);
+assert.equal(
+  await normalizeDocxPageLayout(completePackage, runtime),
+  completePackage
+);
+
+console.log('DOCX missing page size and margin defaults verified.');

--- a/packages/renderers/word/src/docxPageDefaults.ts
+++ b/packages/renderers/word/src/docxPageDefaults.ts
@@ -1,0 +1,252 @@
+import JSZip from 'jszip'
+
+const WORDPROCESSINGML_NAMESPACE =
+  'http://schemas.openxmlformats.org/wordprocessingml/2006/main'
+const DOCUMENT_XML_PATH = 'word/document.xml'
+
+// File Viewer uses an A4 sheet (794 × 1123 CSS pixels at 96 DPI) when a DOCX
+// does not provide page geometry. These are the exact OOXML twip values for
+// the same 210 × 297 mm sheet.
+export const DOCX_DEFAULT_PAGE_LAYOUT = {
+  width: '11906',
+  height: '16838',
+  marginTop: '1440',
+  marginRight: '1440',
+  marginBottom: '1440',
+  marginLeft: '1440',
+  header: '720',
+  footer: '720',
+  gutter: '0'
+} as const
+
+export interface DocxXmlRuntime {
+  parse(xml: string): XMLDocument
+  serialize(document: XMLDocument): string
+}
+
+const SECTION_CHILD_ORDER = [
+  'headerReference',
+  'footerReference',
+  'footnotePr',
+  'endnotePr',
+  'type',
+  'pgSz',
+  'pgMar',
+  'paperSrc',
+  'pgBorders',
+  'lnNumType',
+  'pgNumType',
+  'cols',
+  'formProt',
+  'vAlign',
+  'noEndnote',
+  'titlePg',
+  'textDirection',
+  'bidi',
+  'rtlGutter',
+  'docGrid',
+  'printerSettings'
+]
+
+const getWordChildren = (element: Element) =>
+  Array.from(element.childNodes).filter(
+    (child): child is Element =>
+      child.nodeType === 1 &&
+      (child as Element).namespaceURI === WORDPROCESSINGML_NAMESPACE
+  )
+
+const getWordChild = (element: Element, localName: string) =>
+  getWordChildren(element).find((child) => child.localName === localName) ??
+  null
+
+const getWordAttribute = (element: Element, localName: string) =>
+  element.getAttributeNS(WORDPROCESSINGML_NAMESPACE, localName) ??
+  Array.from(element.attributes).find(
+    (attribute) =>
+      attribute.namespaceURI === WORDPROCESSINGML_NAMESPACE &&
+      attribute.localName === localName
+  )?.value ??
+  null
+
+const setWordAttribute = (
+  element: Element,
+  prefix: string,
+  localName: string,
+  value: string
+) => {
+  element.setAttributeNS(
+    WORDPROCESSINGML_NAMESPACE,
+    `${prefix}:${localName}`,
+    value
+  )
+}
+
+const createWordElement = (
+  document: XMLDocument,
+  prefix: string,
+  localName: string
+) =>
+  document.createElementNS(WORDPROCESSINGML_NAMESPACE, `${prefix}:${localName}`)
+
+const insertSectionChild = (section: Element, child: Element) => {
+  const childOrder = SECTION_CHILD_ORDER.indexOf(child.localName)
+  const before = getWordChildren(section).find((candidate) => {
+    const candidateOrder = SECTION_CHILD_ORDER.indexOf(candidate.localName)
+    return candidateOrder !== -1 && candidateOrder > childOrder
+  })
+
+  section.insertBefore(child, before ?? null)
+}
+
+const ensureSectionChild = (
+  section: Element,
+  document: XMLDocument,
+  prefix: string,
+  localName: string
+) => {
+  const existing = getWordChild(section, localName)
+  if (existing) {
+    return { element: existing, changed: false }
+  }
+
+  const element = createWordElement(document, prefix, localName)
+  insertSectionChild(section, element)
+  return { element, changed: true }
+}
+
+const ensureWordAttribute = (
+  element: Element,
+  prefix: string,
+  localName: string,
+  value: string
+) => {
+  if (getWordAttribute(element, localName) !== null) {
+    return false
+  }
+
+  setWordAttribute(element, prefix, localName, value)
+  return true
+}
+
+const normalizeSectionPageLayout = (
+  section: Element,
+  document: XMLDocument,
+  prefix: string
+) => {
+  let changed = false
+  const pageSize = ensureSectionChild(section, document, prefix, 'pgSz')
+  const orientation = getWordAttribute(pageSize.element, 'orient')
+  const defaultWidth =
+    orientation === 'landscape'
+      ? DOCX_DEFAULT_PAGE_LAYOUT.height
+      : DOCX_DEFAULT_PAGE_LAYOUT.width
+  const defaultHeight =
+    orientation === 'landscape'
+      ? DOCX_DEFAULT_PAGE_LAYOUT.width
+      : DOCX_DEFAULT_PAGE_LAYOUT.height
+
+  changed = pageSize.changed || changed
+  changed =
+    ensureWordAttribute(pageSize.element, prefix, 'w', defaultWidth) || changed
+  changed =
+    ensureWordAttribute(pageSize.element, prefix, 'h', defaultHeight) || changed
+
+  const pageMargins = ensureSectionChild(section, document, prefix, 'pgMar')
+  changed = pageMargins.changed || changed
+  const marginDefaults = [
+    ['top', DOCX_DEFAULT_PAGE_LAYOUT.marginTop],
+    ['right', DOCX_DEFAULT_PAGE_LAYOUT.marginRight],
+    ['bottom', DOCX_DEFAULT_PAGE_LAYOUT.marginBottom],
+    ['left', DOCX_DEFAULT_PAGE_LAYOUT.marginLeft],
+    ['header', DOCX_DEFAULT_PAGE_LAYOUT.header],
+    ['footer', DOCX_DEFAULT_PAGE_LAYOUT.footer],
+    ['gutter', DOCX_DEFAULT_PAGE_LAYOUT.gutter]
+  ] as const
+
+  for (const [name, value] of marginDefaults) {
+    changed =
+      ensureWordAttribute(pageMargins.element, prefix, name, value) || changed
+  }
+
+  return changed
+}
+
+const resolveWordPrefix = (document: XMLDocument, body: Element) =>
+  body.prefix ??
+  document.documentElement.lookupPrefix(WORDPROCESSINGML_NAMESPACE) ??
+  'w'
+
+/**
+ * Supplies Word-compatible application defaults for malformed or generated
+ * DOCX files whose section properties omit page size or margins. Explicit
+ * values, including zero margins and custom page sizes, are never replaced.
+ */
+export const normalizeDocxPageLayout = async (
+  buffer: ArrayBuffer,
+  runtime: DocxXmlRuntime
+) => {
+  const zip = await JSZip.loadAsync(buffer)
+  const documentPart = zip.file(DOCUMENT_XML_PATH)
+  if (!documentPart) {
+    return buffer
+  }
+
+  const source = await documentPart.async('string')
+  const document = runtime.parse(source)
+  if (document.getElementsByTagName('parsererror').length) {
+    return buffer
+  }
+
+  const body = document.getElementsByTagNameNS(
+    WORDPROCESSINGML_NAMESPACE,
+    'body'
+  )[0]
+  if (!body) {
+    return buffer
+  }
+
+  const prefix = resolveWordPrefix(document, body)
+  let sections = Array.from(
+    document.getElementsByTagNameNS(WORDPROCESSINGML_NAMESPACE, 'sectPr')
+  )
+  let changed = false
+
+  if (!sections.length) {
+    const section = createWordElement(document, prefix, 'sectPr')
+    body.appendChild(section)
+    sections = [section]
+    changed = true
+  }
+
+  for (const section of sections) {
+    changed = normalizeSectionPageLayout(section, document, prefix) || changed
+  }
+
+  if (!changed) {
+    return buffer
+  }
+
+  zip.file(DOCUMENT_XML_PATH, runtime.serialize(document))
+  return zip.generateAsync({
+    type: 'arraybuffer',
+    compression: 'DEFLATE',
+    compressionOptions: { level: 6 }
+  })
+}
+
+export const createBrowserDocxXmlRuntime = (
+  document: Document
+): DocxXmlRuntime | null => {
+  const DOMParserConstructor = document.defaultView?.DOMParser
+  const XMLSerializerConstructor = document.defaultView?.XMLSerializer
+  if (!DOMParserConstructor || !XMLSerializerConstructor) {
+    return null
+  }
+
+  return {
+    parse: (xml) =>
+      new DOMParserConstructor().parseFromString(xml, 'application/xml'),
+    serialize: (xmlDocument) =>
+      new XMLSerializerConstructor().serializeToString(xmlDocument)
+  }
+}

--- a/packages/renderers/word/src/wordDocx.ts
+++ b/packages/renderers/word/src/wordDocx.ts
@@ -24,6 +24,10 @@ import {
   type FileViewerZoomState,
   type PrintPageSize,
 } from '@file-viewer/core'
+import {
+  createBrowserDocxXmlRuntime,
+  normalizeDocxPageLayout
+} from './docxPageDefaults.js'
 
 const DOCX_DEFAULT_PAGE_SIZE: PrintPageSize = {
   width: 794,
@@ -667,10 +671,14 @@ export default async function(buffer: ArrayBuffer, target: HTMLDivElement, conte
   }
   const docxOptions = createDocxOptions(target, context, notifyProgressiveRender)
   const { defaultOptions, renderAsync } = await loadLibrary()
+  const xmlRuntime = createBrowserDocxXmlRuntime(target.ownerDocument)
+  const renderBuffer = xmlRuntime
+    ? await normalizeDocxPageLayout(buffer, xmlRuntime)
+    : buffer
 
   target.dataset.docxWorker = docxOptions.useWorker ? 'self' : 'false'
   target.dataset.docxDarkMode = docxOptions.darkMode ? 'true' : 'false'
-  const usedHeaderFooterFallback = await renderDocxWithHeaderFooterFallback(renderAsync, buffer, target, {
+  const usedHeaderFooterFallback = await renderDocxWithHeaderFooterFallback(renderAsync, renderBuffer, target, {
     ...defaultOptions,
     ...docxOptions
   })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1326,6 +1326,9 @@ importers:
         specifier: ^3.0.9
         version: 3.0.9
     devDependencies:
+      '@xmldom/xmldom':
+        specifier: 0.9.10
+        version: 0.9.10
       typescript:
         specifier: ^6.0.3
         version: 6.0.3


### PR DESCRIPTION
## Summary

- supply Word-compatible page geometry when a DOCX omits `sectPr`, `pgSz`, or `pgMar`
- use the existing A4 viewer default with 1-inch margins while preserving explicit custom sizes, landscape layout, and zero margins
- normalize the in-memory DOCX before the existing `@file-viewer/docx` render path
- add focused regression coverage for missing and partial section properties

## Validation

- both reported DOCX files render with the expected page size and margins; embedded attachments remain visible
- DOCX page-default regression
- all renderer and preset builds
- demo type-check, production build, and browser visual regression
