### PR TITLE
fix(spreadsheet): cap chartText points to prevent RangeError on large workbooks

### DIFF
--- a/packages/renderers/spreadsheet/src/spreadsheet/worker/sheetjs/chartParser.ts
+++ b/packages/renderers/spreadsheet/src/spreadsheet/worker/sheetjs/chartParser.ts
@@ -213,6 +213,8 @@ const parsePointValues = (element: XmlElement | undefined) => {
     .map((point) => point.value)
 }
 
+const CHART_TEXT_POINTS_LIMIT = 200
+
 const chartText = (element: XmlElement | undefined) => {
   if (!element) {
     return ''
@@ -220,6 +222,12 @@ const chartText = (element: XmlElement | undefined) => {
 
   const points = parsePointValues(element)
   if (points.length) {
+    if (points.length > CHART_TEXT_POINTS_LIMIT) {
+      console.warn(
+        `[file-viewer] chartText truncated ${points.length} points to ${CHART_TEXT_POINTS_LIMIT}.`
+      )
+      return points.slice(0, CHART_TEXT_POINTS_LIMIT).join(' ').trim()
+    }
     return points.join(' ').trim()
   }
 


### PR DESCRIPTION
## Summary

Fixes `RangeError: Invalid string length at Array.join` that occurs when rendering
large spreadsheets (70MB+ xlsx) containing charts with extensive data series.

## Root Cause

In `chartParser.ts`, `chartText()` uses `elementsByLocal(element, "pt")` to
recursively collect ALL `<c:pt>` elements from chart XML text nodes, then joins
them with `points.join(" ")`.

For pathologically large workbooks where chart categories or series reference
tens/hundreds of thousands of data points via `<c:strRef>`, a text element
(e.g., chart title, axis label, series name) can inadvertently pick up a
massive `<c:rich>` block containing every cached data point as `<c:pt>` entries.

`Array.join` on 100,000+ short strings produces a result string that can exceed
V8's maximum string length (~512MB in practice, limited by available memory),
throwing `RangeError`.

This error is currently caught in `parseSpreadsheetWorkbook` and silently drops
all charts (`context.charts = {}`), so users see only cell data — no charts
render even for smaller sheets in the same workbook.

## Fix

Added `CHART_TEXT_POINTS_LIMIT = 200` cap in `chartText()`. When `parsePointValues`
returns more than 200 entries, the result is truncated with a `console.warn`.

Chart titles, axis labels, and series names are inherently short text — 200
`<c:pt>` runs is far beyond any reasonable text element. Data values in
`parseSeries` use `parsePointValues` directly without join, so they are
unaffected.

## Verification

- Small xlsx files: no change in behavior (points count stays below 200)
- Large xlsx with chart data: truncated instead of crashing with RangeError;
  charts render with the first 200 chars of the text element
- Other renderers: no impact (spreadsheet-only change)

## Additional Context

Two errors appear in the console for large xlsx files:

```
1. [file-viewer] Spreadsheet Worker 自动模式启动失败，已回退到主线程解析。
2. [file-viewer] Spreadsheet chart parsing failed; continuing with cell content.
   RangeError: Invalid string length
```

Error #1 is **expected behavior**: `shouldUseSpreadsheetWorker` threshold is
1MB. Files above 1MB spawn a Web Worker, but the Worker runs out of memory
parsing the 70MB workbook (structured clone of the ArrayBuffer + styled-exceljs
in-memory representation + JSZip copy for chart parsing). The
`AutoFallbackSpreadsheetWorker` correctly detects this and replays pending
messages to the main-thread fallback.

Using `postMessage` with transfer list is **incompatible** with the auto-fallback
design — if the ArrayBuffer is transferred (not cloned), the main thread loses
ownership, and the fallback replay would receive a detached (zero-length) buffer.

Error #2 is the bug fixed by this PR.

## Related

Observed in production rendering 70MB+ xlsx files on `@file-viewer/preset-all` v2.2.5.