### PR TITLE
fix(word): block external DOCX links

### DIFF
--- a/packages/core/src/contracts/types.ts
+++ b/packages/core/src/contracts/types.ts
@@ -700,6 +700,8 @@ export interface FileViewerDocxOptions {
   updatePageReferences?: boolean;
   hideWebHiddenContent?: boolean;
   ignoreLastRenderedPageBreak?: boolean;
+  /** External DOCX links are blocked by default; internal bookmark links remain active. */
+  externalLinkPolicy?: 'allow' | 'block';
   /** Overrides automatic DOCX dark rendering derived from the viewer theme. */
   darkMode?: boolean;
 }

--- a/packages/renderers/word/src/wordDocx.ts
+++ b/packages/renderers/word/src/wordDocx.ts
@@ -68,6 +68,10 @@ type DocxLibraryImport = DocxLibrary & {
 }
 
 type DocxRenderAsync = typeof renderAsync
+type DocxExternalLinkPolicy = NonNullable<FileViewerDocxOptions['externalLinkPolicy']>
+type DocxRenderOptions = Partial<Options> & {
+  externalLinkPolicy: DocxExternalLinkPolicy
+}
 
 // Modern bundlers expose the ESM named exports, while some legacy webpack
 // configurations wrap the CommonJS browser API in `default`.
@@ -366,11 +370,36 @@ const appendDocxVendorAssetVersion = (url: string | undefined, explicitUrl: bool
   return `${url}${url.includes('?') ? '&' : '?'}file-viewer-docx=${DOCX_VENDOR_ASSET_VERSION}`
 }
 
-const createDocxOptions = (
+export const applyDocxExternalLinkPolicy = (
+  target: Pick<ParentNode, 'querySelectorAll'>,
+  policy: DocxExternalLinkPolicy
+) => {
+  if (policy === 'allow') {
+    return 0
+  }
+
+  let blocked = 0
+  target.querySelectorAll<HTMLAnchorElement>('a[href]').forEach(anchor => {
+    const href = anchor.getAttribute('href')
+    if (!href || href.startsWith('#')) {
+      return
+    }
+
+    if (!anchor.hasAttribute('data-docx-external-href')) {
+      anchor.setAttribute('data-docx-external-href', href)
+    }
+    anchor.removeAttribute('href')
+    anchor.setAttribute('aria-disabled', 'true')
+    blocked += 1
+  })
+  return blocked
+}
+
+export const createDocxOptions = (
   target: HTMLDivElement,
   context: FileRenderContext | undefined,
   notifyProgressiveRender: () => void
-): Partial<Options> => {
+): DocxRenderOptions => {
   const docxOptions = context?.options?.docx
   const documentBaseUrl = resolveFileViewerRuntimeAssetBaseUrl(target.ownerDocument)
   const useWorker = shouldUseDocxWorker(target, docxOptions)
@@ -382,12 +411,19 @@ const createDocxOptions = (
     }
   }
 
-  const options: Partial<Options> = {
+  const externalLinkPolicy = docxOptions?.externalLinkPolicy ?? 'block'
+  const options: DocxRenderOptions = {
     useWorker,
     breakPages: usePagedLayout,
     ignoreLastRenderedPageBreak: docxOptions?.ignoreLastRenderedPageBreak ?? !usePagedLayout,
+    externalLinkPolicy,
     darkMode,
-    progress
+    progress: event => {
+      if (event.phase === 'render' || event.phase === 'layout' || event.phase === 'done') {
+        applyDocxExternalLinkPolicy(target, externalLinkPolicy)
+      }
+      progress(event)
+    }
   }
 
   if (useWorker) {
@@ -848,6 +884,7 @@ export default async function(buffer: ArrayBuffer, target: HTMLDivElement, conte
     ...defaultOptions,
     ...docxOptions
   })
+  applyDocxExternalLinkPolicy(target, docxOptions.externalLinkPolicy)
   target.dataset.docxHeaderFooterFallback = usedHeaderFooterFallback ? 'true' : 'false'
   target.dataset.docxPageBackground =
     applyDocxPageBackgroundImage(target, pageBackgroundImage) > 0 ? 'true' : 'false'


### PR DESCRIPTION
Fixes #183.

## Reproduction
- Render DOCX output containing both relationship hyperlinks, field-code hyperlinks, and an internal bookmark.
- External links remain clickable in the preview even when the host must prevent navigation.

## Fix
- Default DOCX external links to blocked at the File Viewer boundary.
- Keep internal `#bookmark` links active.
- Add `options.docx.externalLinkPolicy: "allow" | "block"` for explicit opt-in.
- Reapply the policy during progressive render phases and after final render.

## Local verification
- `pnpm verify:issue-183-docx-links`
- Five focused tests passed, including both generated link forms, bookmarks, the default policy, and the allow override.
- Public-boundary verification passed.