### PR TITLE
fix(spreadsheet): avoid reinflating large worksheets

### DIFF
--- a/packages/renderers/spreadsheet/src/spreadsheet/worker/sheetjs/chartParser.ts
+++ b/packages/renderers/spreadsheet/src/spreadsheet/worker/sheetjs/chartParser.ts
@@ -372,18 +372,17 @@ export const parseSpreadsheetCharts = async (data: ArrayBuffer) => {
       continue
     }
 
-    const [worksheetDocument, worksheetRelationships] = await Promise.all([
-      loadXml(zip, worksheetRelationship.target),
-      loadRelationships(zip, worksheetRelationship.target)
-    ])
-    if (!worksheetDocument) {
-      continue
-    }
-
-    const drawingParts = elementsByLocal(worksheetDocument.documentElement, 'drawing')
-      .map((drawing) => relationById(worksheetRelationships, relationshipId(drawing)))
-      .filter((relationship) => relationship?.type.endsWith(DRAWING_RELATIONSHIP_SUFFIX))
-      .map((relationship) => relationship!.target)
+    // A worksheet can expand to hundreds of megabytes even when the drawing
+    // relationship part is only a few hundred bytes. Loading sheetN.xml as a
+    // string here duplicates the cell parser's work and can exceed V8's string
+    // limit before chart parsing starts. Drawing relationships already carry
+    // the typed targets needed by the chart parser, so discover them directly.
+    const worksheetRelationships = await loadRelationships(zip, worksheetRelationship.target)
+    const drawingParts = Array.from(new Set(
+      worksheetRelationships
+        .filter((relationship) => relationship.type.endsWith(DRAWING_RELATIONSHIP_SUFFIX))
+        .map((relationship) => relationship.target)
+    ))
     const charts = (
       await Promise.all(drawingParts.map((part) => parseDrawingCharts(zip, part)))
     ).flat()


### PR DESCRIPTION
Refs #173.

This fixes the reported JSZip chart-parser failure. The separate Worker auto-mode failure still needs the reporter’s workbook or an equivalent sanitized sample.

## Reproduction
The regression builds a valid XLSX with a 16 MiB worksheet XML, a worksheet drawing relationship, and a chart. It injects the reported `RangeError: Invalid string length` whenever chart discovery requests `xl/worksheets/sheet1.xml` as text.

Before this change, chart discovery expands every worksheet XML just to find `<drawing>` references, so it reaches JSZip’s string conversion before any proposed chart-point cap.

## Fix
Discover typed drawing targets directly from each worksheet `.rels` part. This avoids a second expansion of cell data while retaining drawing targets, chart anchors, categories, and values. Duplicate drawing targets are ignored.

## Local verification
- `pnpm verify:issue-173-large-spreadsheet`
- 16 MiB synthetic worksheet parsed with its cell sheet and chart intact; worksheet text reads remained zero
- 19 spreadsheet tests passed
- Existing GitHub #96 and #175 spreadsheet regressions passed
- Spreadsheet renderer build and full demo build passed
- 28-case smoke matrix passed
- Real-browser `excel.xlsx` demo smoke passed
- Public-boundary verification passed