### PR TITLE
fix(presentation): split PPT and PPTX entrypoints

### DIFF
--- a/apps/viewer-demo/scripts/verify-presentation-entrypoints.mjs
+++ b/apps/viewer-demo/scripts/verify-presentation-entrypoints.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { readFile, readdir, rm, writeFile, mkdtemp } from 'node:fs/promises'
+import { readFile, readdir, realpath, rm, stat, writeFile, mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -26,7 +26,9 @@ assert.deepEqual(pptSelection.rendererIds, ['office-presentation-binary'])
 assert.deepEqual(pptxSelection.packages, ['@file-viewer/renderer-presentation/pptx'])
 assert.deepEqual(pptxSelection.rendererIds, ['office-presentation'])
 
-const fixtureRoot = await mkdtemp(join(tmpdir(), 'file-viewer-pptx-only-'))
+const fixtureRoot = await realpath(
+  await mkdtemp(join(await realpath(tmpdir()), 'file-viewer-pptx-only-'))
+)
 try {
   await writeFile(join(fixtureRoot, 'index.html'), '<script type="module" src="/src.js"></script>\n')
   await writeFile(join(fixtureRoot, 'src.js'), "console.log('PPTX-only fixture');\n")
@@ -49,10 +51,30 @@ try {
   const outputFiles = await readdir(join(fixtureRoot, 'dist'), {
     recursive: true
   })
+  const outputRecords = []
+  for (const file of outputFiles) {
+    const path = join(fixtureRoot, 'dist', file)
+    const info = await stat(path)
+    if (!info.isFile()) continue
+    const body = await readFile(path)
+    outputRecords.push({ file, body })
+  }
   const legacyPptAssets = outputFiles.filter((file) =>
     /(?:ppt-font-cjk|ppt-native|file-viewer-presentation-ppt\b)/i.test(file)
   )
   assert.deepEqual(legacyPptAssets, [], `PPTX-only build emitted legacy PPT assets: ${legacyPptAssets.join(', ')}`)
+  const legacyPptReferences = outputRecords.filter(({ file, body }) =>
+    /(?:ppt-font-cjk|ppt-native\.wasm|Flyfish PPT Viewer)/i.test(`${file}\n${body.toString('utf8')}`)
+  )
+  assert.deepEqual(
+    legacyPptReferences.map(({ file }) => file),
+    [],
+    `PPTX-only build retained legacy PPT references: ${legacyPptReferences.map(({ file }) => file).join(', ')}`
+  )
+  assert.ok(
+    outputFiles.some((file) => /pptx\.worker/i.test(file)),
+    `PPTX-only build did not emit a PPTX renderer worker: ${outputFiles.join(', ')}`
+  )
 } finally {
   await rm(fixtureRoot, { recursive: true, force: true })
 }

--- a/apps/viewer-demo/scripts/verify-presentation-entrypoints.mjs
+++ b/apps/viewer-demo/scripts/verify-presentation-entrypoints.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict'
+import { readFile, readdir, rm, writeFile, mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { build } from 'vite'
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
+const presentationPackagePath = join(root, 'packages/renderers/presentation/package.json')
+const pptxEntryPath = join(root, 'packages/renderers/presentation/dist/pptx.js')
+const vitePluginEntryPath = join(root, 'packages/presets/vite-plugin/dist/index.js')
+
+const presentationPackage = JSON.parse(await readFile(presentationPackagePath, 'utf8'))
+assert.equal(presentationPackage.exports['./ppt']?.import, './dist/ppt.js')
+assert.equal(presentationPackage.exports['./pptx']?.import, './dist/pptx.js')
+
+const {
+  default: fileViewerRenderers,
+  resolveFileViewerRendererSelection
+} = await import(vitePluginEntryPath)
+const pptSelection = resolveFileViewerRendererSelection({ formats: ['ppt'] })
+const pptxSelection = resolveFileViewerRendererSelection({ formats: ['pptx'] })
+
+assert.deepEqual(pptSelection.packages, ['@file-viewer/renderer-presentation/ppt'])
+assert.deepEqual(pptSelection.rendererIds, ['office-presentation-binary'])
+assert.deepEqual(pptxSelection.packages, ['@file-viewer/renderer-presentation/pptx'])
+assert.deepEqual(pptxSelection.rendererIds, ['office-presentation'])
+
+const fixtureRoot = await mkdtemp(join(tmpdir(), 'file-viewer-pptx-only-'))
+try {
+  await writeFile(join(fixtureRoot, 'index.html'), '<script type="module" src="/src.js"></script>\n')
+  await writeFile(join(fixtureRoot, 'src.js'), "console.log('PPTX-only fixture');\n")
+
+  await build({
+    root: fixtureRoot,
+    logLevel: 'silent',
+    plugins: [fileViewerRenderers({ formats: ['pptx'], autoPresets: false })],
+    resolve: {
+      alias: {
+        '@file-viewer/renderer-presentation/pptx': pptxEntryPath
+      }
+    },
+    build: {
+      manifest: true,
+      outDir: 'dist'
+    }
+  })
+
+  const outputFiles = await readdir(join(fixtureRoot, 'dist'), {
+    recursive: true
+  })
+  const legacyPptAssets = outputFiles.filter((file) =>
+    /(?:ppt-font-cjk|ppt-native|file-viewer-presentation-ppt\b)/i.test(file)
+  )
+  assert.deepEqual(legacyPptAssets, [], `PPTX-only build emitted legacy PPT assets: ${legacyPptAssets.join(', ')}`)
+} finally {
+  await rm(fixtureRoot, { recursive: true, force: true })
+}
+
+console.log('Presentation subpath and PPTX-only bundle verification passed.')

--- a/apps/viewer-demo/scripts/verify-presentation-entrypoints.mjs
+++ b/apps/viewer-demo/scripts/verify-presentation-entrypoints.mjs
@@ -7,7 +7,6 @@ import { build } from 'vite'
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '../../..')
 const presentationPackagePath = join(root, 'packages/renderers/presentation/package.json')
-const pptxEntryPath = join(root, 'packages/renderers/presentation/dist/pptx.js')
 const vitePluginEntryPath = join(root, 'packages/presets/vite-plugin/dist/index.js')
 
 const presentationPackage = JSON.parse(await readFile(presentationPackagePath, 'utf8'))
@@ -37,11 +36,6 @@ try {
     root: fixtureRoot,
     logLevel: 'silent',
     plugins: [fileViewerRenderers({ formats: ['pptx'], autoPresets: false })],
-    resolve: {
-      alias: {
-        '@file-viewer/renderer-presentation/pptx': pptxEntryPath
-      }
-    },
     build: {
       manifest: true,
       outDir: 'dist'

--- a/docs/guide/on-demand-renderers.md
+++ b/docs/guide/on-demand-renderers.md
@@ -68,6 +68,9 @@ Install a single renderer when a product needs the smallest possible capability 
 | `@file-viewer/renderer-3d` | `modelRenderer` | 3D models and lightweight geometry signatures |
 
 Binary PowerPoint and OpenXML PowerPoint share the presentation plugin but keep separate lazy engine boundaries. The packaged `.ppt` 0.3.3 runtime is zero-config in standard layouts; for custom asset layouts, configure `presentation.pptModuleUrl` / `pptWorkerUrl` / `pptWasmUrl` / `pptFontUrl`. PPTX continues to use `presentation.workerUrl` / `workerType`.
+
+Strict PPTX-only applications can import `pptxRenderer` from `@file-viewer/renderer-presentation/pptx`, or configure `fileViewerRenderers({ formats: ['pptx'] })`. Both paths exclude the classic `.ppt` font and WASM from the production output. The matching binary-only entry is `@file-viewer/renderer-presentation/ppt`.
+
 | `@file-viewer/renderer-drawing` | `drawingRenderer` | draw.io, Excalidraw, Mermaid, PlantUML |
 | `@file-viewer/renderer-mindmap` | `mindmapRenderer` | XMind |
 | `@file-viewer/renderer-geo` | `geoRenderer` | GeoJSON, KML, GPX, SHP |

--- a/docs/zh/guide/on-demand-renderers.md
+++ b/docs/zh/guide/on-demand-renderers.md
@@ -100,6 +100,8 @@ export default defineConfig({
 | `inject:false` | 关闭自动注入，改为手动导入 `virtual:file-viewer-renderers` 并传给 `options.renderers` |
 | `chunkStrategy:'renderer'` | 使用 renderer 级 chunk 命名，便于缓存和定位体积问题 |
 
+PPTX-only 项目可以直接从 `@file-viewer/renderer-presentation/pptx` 导入 `pptxRenderer`，或配置 `fileViewerRenderers({ formats: ['pptx'] })`。两条路径都不会把传统 `.ppt` 的 CJK 字体和 WASM 写入生产产物。只需要二进制 `.ppt` 时使用 `@file-viewer/renderer-presentation/ppt`；两种格式都需要时继续使用根入口 `presentationRenderer`。
+
 ## 2.1.0 推荐接入步骤
 
 ### 最小化引入：只要一个格式就只装一个 renderer

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "docs:preview": "pnpm --filter @flyfish-group/file-viewer-docs preview",
     "verify:vue3-toolbar-browser": "node apps/component-demo/scripts/verify-vue3-toolbar-browser.mjs",
     "verify:renderer-sanitization": "pnpm --filter @file-viewer/pptx build && node apps/viewer-demo/scripts/verify-renderer-sanitization.mjs",
+    "verify:presentation-entrypoints": "pnpm --filter @file-viewer/core build && pnpm --filter @file-viewer/pptx build && pnpm --filter @file-viewer/renderer-presentation build && pnpm --filter @file-viewer/vite-plugin build && node apps/viewer-demo/scripts/verify-presentation-entrypoints.mjs",
     "verify:browser-smoke": "node apps/viewer-demo/scripts/public-smoke.mjs",
     "verify:pptx-slideshow": "npm exec --yes --package playwright -- node apps/viewer-demo/scripts/verify-pptx-slideshow.mjs"
   },

--- a/packages/presets/vite-plugin/src/index.ts
+++ b/packages/presets/vite-plugin/src/index.ts
@@ -204,19 +204,25 @@ const rendererModules: readonly RendererModuleDescriptor[] = [
     id: 'presentation',
     packageName: '@file-viewer/renderer-presentation',
     exportName: 'presentationRenderer',
-    formats: [
-      'presentation',
-      'ppt',
-      'pptx',
-      'pptm',
-      'pot',
-      'potx',
-      'potm',
-      'ppsx',
-      'ppsm'
-    ],
+    formats: ['presentation'],
     rendererIds: ['office-presentation-binary', 'office-presentation'],
     chunkName: 'file-viewer-presentation'
+  },
+  {
+    id: 'presentation-binary',
+    packageName: '@file-viewer/renderer-presentation/ppt',
+    exportName: 'pptRenderer',
+    formats: ['ppt', 'pot'],
+    rendererIds: ['office-presentation-binary'],
+    chunkName: 'file-viewer-presentation-ppt'
+  },
+  {
+    id: 'presentation-openxml',
+    packageName: '@file-viewer/renderer-presentation/pptx',
+    exportName: 'pptxRenderer',
+    formats: ['pptx', 'pptm', 'potx', 'potm', 'ppsx', 'ppsm'],
+    rendererIds: ['office-presentation'],
+    chunkName: 'file-viewer-presentation-pptx'
   },
   {
     id: 'word',

--- a/packages/presets/vite-plugin/src/index.ts
+++ b/packages/presets/vite-plugin/src/index.ts
@@ -1373,10 +1373,40 @@ function resolvePackageEntry(packageName: string, anchorPackages: readonly strin
     return null
   }
   const packageRoot = dirname(packageJsonPath)
+  const anchorPackageJson = anchorPackages
+    .map((anchorPackage) => resolvePackageJson(anchorPackage))
+    .find(Boolean)
+  const requireFns = [
+    projectRequire(),
+    pluginRequire,
+    ...(anchorPackageJson ? [createRequire(anchorPackageJson)] : [])
+  ]
   try {
     const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8')) as {
+      name?: string
       main?: string
       module?: string
+      exports?: Record<string, unknown>
+    }
+    const exportSubpath = packageJson.name && packageName.startsWith(`${packageJson.name}/`)
+      ? `.${packageName.slice(packageJson.name.length)}`
+      : null
+    if (exportSubpath) {
+      const exportedEntry = readPackageExportEntry(packageJson.exports?.[exportSubpath])
+      if (exportedEntry) {
+        const entry = resolve(packageRoot, exportedEntry)
+        if (existsSync(entry) && statSync(entry).isFile()) {
+          return entry
+        }
+      }
+      for (const requireFn of requireFns) {
+        try {
+          return requireFn.resolve(packageName)
+        } catch {
+          // Continue probing alternate anchors.
+        }
+      }
+      return null
     }
     const candidates = unique([
       packageJson.module,
@@ -1393,14 +1423,6 @@ function resolvePackageEntry(packageName: string, anchorPackages: readonly strin
     // Fall back to Node resolution below.
   }
 
-  const anchorPackageJson = anchorPackages
-    .map((anchorPackage) => resolvePackageJson(anchorPackage))
-    .find(Boolean)
-  const requireFns = [
-    projectRequire(),
-    pluginRequire,
-    ...(anchorPackageJson ? [createRequire(anchorPackageJson)] : [])
-  ]
   for (const requireFn of requireFns) {
     try {
       return requireFn.resolve(packageName)

--- a/packages/renderers/presentation/README.en.md
+++ b/packages/renderers/presentation/README.en.md
@@ -14,6 +14,28 @@ const options = {
 }
 ```
 
+When an application needs only one PowerPoint family, use a stable subpath so the other engine stays out of the production bundle:
+
+```ts
+import { pptRenderer } from '@file-viewer/renderer-presentation/ppt'
+import { pptxRenderer } from '@file-viewer/renderer-presentation/pptx'
+
+const pptxOnlyOptions = {
+  rendererMode: 'replace',
+  renderers: pptxRenderer,
+}
+```
+
+Vite can generate the same PPTX-only import:
+
+```ts
+import { fileViewerRenderers } from '@file-viewer/vite-plugin'
+
+fileViewerRenderers({ formats: ['pptx'] })
+```
+
+This configuration does not emit the classic `.ppt` CJK font or WASM in production. Keep using the root `presentationRenderer` when both families are required.
+
 You can compose it with other renderers:
 
 ```ts

--- a/packages/renderers/presentation/README.md
+++ b/packages/renderers/presentation/README.md
@@ -14,6 +14,28 @@ const options = {
 }
 ```
 
+只需要一种 PowerPoint 格式族时，使用稳定子路径避免另一条引擎进入生产 bundle：
+
+```ts
+import { pptRenderer } from '@file-viewer/renderer-presentation/ppt'
+import { pptxRenderer } from '@file-viewer/renderer-presentation/pptx'
+
+const pptxOnlyOptions = {
+  rendererMode: 'replace',
+  renderers: pptxRenderer,
+}
+```
+
+Vite 项目也可以让插件生成同一条 PPTX-only import：
+
+```ts
+import { fileViewerRenderers } from '@file-viewer/vite-plugin'
+
+fileViewerRenderers({ formats: ['pptx'] })
+```
+
+这种配置不会在生产产物中生成传统 `.ppt` 的 CJK 字体或 WASM；需要同时支持两种格式时继续使用根入口 `presentationRenderer`。
+
 也可以和其他 renderer 组合：
 
 ```ts

--- a/packages/renderers/presentation/package.json
+++ b/packages/renderers/presentation/package.json
@@ -46,6 +46,16 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./ppt": {
+      "types": "./dist/ppt.d.ts",
+      "import": "./dist/ppt.js",
+      "default": "./dist/ppt.js"
+    },
+    "./pptx": {
+      "types": "./dist/pptx.d.ts",
+      "import": "./dist/pptx.js",
+      "default": "./dist/pptx.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/packages/renderers/presentation/src/ppt.ts
+++ b/packages/renderers/presentation/src/ppt.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_RENDERER_DEFINITIONS,
   createFileViewerTranslator,
   createFileViewerZoomChangeEmitter,
   normalizeFileViewerErrorMessage,
@@ -11,10 +12,13 @@ import {
 } from '@file-viewer/core';
 import type {
   FileRenderContext,
+  FileRenderHandler,
   FileRenderExportAdapter,
   FileViewerFitRequest,
   FileViewerRenderedInstance,
+  FileViewerRendererPlugin,
   FileViewerZoomState,
+  RendererDefinition,
 } from '@file-viewer/core';
 import type {
   LoadPptViewerOptions,
@@ -641,3 +645,26 @@ export default async function renderPpt(
     },
   };
 }
+
+const binaryPresentationDefinition = DEFAULT_RENDERER_DEFINITIONS.find(
+  definition => definition.id === 'office-presentation-binary'
+) as RendererDefinition | undefined;
+
+if (!binaryPresentationDefinition) {
+  throw new Error('@file-viewer/renderer-presentation/ppt could not locate the core PPT renderer definition.');
+}
+
+export const binaryPresentationRendererDefinition = binaryPresentationDefinition;
+export const renderFileViewerBinaryPresentation = renderPpt as FileRenderHandler<FileViewerRenderedInstance, HTMLDivElement>;
+
+export const pptRenderer: FileViewerRendererPlugin<FileRenderHandler<FileViewerRenderedInstance, HTMLDivElement>> = {
+  id: 'file-viewer-renderer-presentation-ppt',
+  label: 'Flyfish File Viewer PPT renderer',
+  definitions: [binaryPresentationRendererDefinition],
+  handlers: [
+    {
+      rendererId: binaryPresentationRendererDefinition.id,
+      handler: renderFileViewerBinaryPresentation,
+    },
+  ],
+};

--- a/packages/renderers/presentation/src/pptx.ts
+++ b/packages/renderers/presentation/src/pptx.ts
@@ -1,5 +1,6 @@
 import { PptxViewer, RECOMMENDED_ZIP_LIMITS } from '@file-viewer/pptx';
 import {
+  DEFAULT_RENDERER_DEFINITIONS,
   createFileViewerTranslator,
   createFileViewerZoomChangeEmitter,
   getFileViewerShadowRootForNode,
@@ -13,9 +14,12 @@ import {
 } from '@file-viewer/core';
 import type {
   FileRenderContext,
+  FileRenderHandler,
   FileRenderExportAdapter,
   FileViewerRenderedInstance,
+  FileViewerRendererPlugin,
   FileViewerZoomState,
+  RendererDefinition,
 } from '@file-viewer/core';
 import type { PptxDiagnosticError } from '@file-viewer/pptx';
 
@@ -742,3 +746,26 @@ export default async function renderPptx(
     unmount: cleanup,
   };
 }
+
+const presentationDefinition = DEFAULT_RENDERER_DEFINITIONS.find(
+  definition => definition.id === 'office-presentation'
+) as RendererDefinition | undefined;
+
+if (!presentationDefinition) {
+  throw new Error('@file-viewer/renderer-presentation/pptx could not locate the core PPTX renderer definition.');
+}
+
+export const presentationRendererDefinition = presentationDefinition;
+export const renderFileViewerPresentation = renderPptx as FileRenderHandler<FileViewerRenderedInstance, HTMLDivElement>;
+
+export const pptxRenderer: FileViewerRendererPlugin<FileRenderHandler<FileViewerRenderedInstance, HTMLDivElement>> = {
+  id: 'file-viewer-renderer-presentation-pptx',
+  label: 'Flyfish File Viewer PPTX renderer',
+  definitions: [presentationRendererDefinition],
+  handlers: [
+    {
+      rendererId: presentationRendererDefinition.id,
+      handler: renderFileViewerPresentation,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- expose separate `@file-viewer/renderer-presentation/ppt` and `/pptx` renderer entrypoints
- map Vite `ppt` and `pptx` format selections to their matching renderer only
- add a production-bundle regression check that rejects legacy PPT assets in a PPTX-only build

## Verification

- [x] `pnpm type-check`
- [x] `pnpm docs:build`
- [x] `pnpm verify:presentation-entrypoints`

## Notes

- Related issue: #205
- File types affected: `ppt`, `pot`, `pptx`, `pptm`, `potx`, `potm`, `ppsx`, `ppsm`
- Deployment paths affected: Vite production bundles using format-specific presentation renderers
