### PR TITLE
docs(renderers): clarify optional renderer setup for Full packages

### DIFF
--- a/docs/guide/on-demand-renderers.md
+++ b/docs/guide/on-demand-renderers.md
@@ -60,92 +60,60 @@ The plugin reads the Vite major installed by the application. Vite 5–7 receive
 
 ## Optional Specialist Renderers
 
-Some specialist capabilities are intentionally **opt-in**. Optional renderers are not installed automatically by the historical `@file-viewer/*-full` packages or by the frozen `@file-viewer/preset-all` compatibility matrix. This keeps existing upgrades stable and prevents large or specialized dependencies from being added unless an application explicitly asks for them.
-
-The table below lists the currently published optional specialist renderers:
+DICOM and digital-signature inspection are explicit opt-ins. They are not dependencies of the eight published `@file-viewer/*-full` packages or `@file-viewer/preset-all`. This preserves the published Full contract and avoids adding medical-imaging or cryptographic dependencies during an ordinary upgrade.
 
 | Optional renderer | Formats | Direct npm install | CLI selection | What the viewer shows |
 | --- | --- | --- | --- | --- |
-| **DICOM** (`@file-viewer/renderer-dicom`) | `.dcm`, `.dicom` | `npm install @file-viewer/renderer-dicom` | `npx file-viewer-cli config add dicom --write` | Local DICOM Part 10 single-frame and multi-frame images with frame navigation, window width/center, zoom, pan, 90° rotation, fit-to-view, and basic image metadata. It is a preview aid, not a diagnostic workstation. |
-| **Digital signatures** (`@file-viewer/renderer-signature`) | `.p7m`, `.p7s`, `.p7b`, `.p7c`, `.pkcs7`, `.cms`, `.cmsc`, `.tsq`, `.tsr`, `.tst`, `.tsd`, `.asics`, `.scs`, `.asice`, `.sce`, `.ers`, `.jws`, `.asc`, `.sig`, `.pgp`, `.gpg` | `npm install @file-viewer/renderer-signature` | `npx file-viewer-cli config add p7m --write` | Browser-local inspection of CMS/PKCS#7 and selected CAdES data, timestamps, ASiC containers, evidence records, JWS, and OpenPGP. It can show signers, certificates, algorithms, digest/signature verification results, timestamps, and safely extracted embedded documents. |
+| **DICOM** (`@file-viewer/renderer-dicom`) | `.dcm`, `.dicom` | `npm install @file-viewer/renderer-dicom` | `npx file-viewer-cli config add dicom --write` | One local DICOM Part 10 file, including multi-frame navigation, window width/center, zoom, pan, rotation, fit-to-view, and basic metadata. It does not assemble studies or provide PACS/DICOMweb, MPR, segmentation, or diagnosis. |
+| **Digital signatures** (`@file-viewer/renderer-signature`) | `.p7m`, `.p7s`, `.p7b`, `.p7c`, `.pkcs7`, `.cms`, `.cmsc`, `.tsq`, `.tsr`, `.tst`, `.tsd`, `.asics`, `.scs`, `.asice`, `.sce`, `.ers`, `.jws`, `.asc`, `.sig`, `.pgp`, `.gpg` | `npm install @file-viewer/renderer-signature` | `npx file-viewer-cli config add p7m --write` | Bounded browser-local inspection of CMS/PKCS#7, selected CAdES data, timestamps, ASiC containers, evidence records, JWS, and public OpenPGP inputs. Parsing, digest, signature, and timestamp results are reported separately. |
 
 ### I already use a Full package. How do I enable an optional renderer?
 
-The same rule applies to every historical Full package: `@file-viewer/web-full`, `@file-viewer/vue3-full`, `@file-viewer/vue2.7-full`, `@file-viewer/vue2.6-full`, `@file-viewer/react-full`, `@file-viewer/react-legacy-full`, `@file-viewer/jquery-full`, and `@file-viewer/svelte-full`.
+The same rule applies to `@file-viewer/web-full`, `@file-viewer/vue3-full`, `@file-viewer/vue2.7-full`, `@file-viewer/vue2.6-full`, `@file-viewer/react-full`, `@file-viewer/react-legacy-full`, `@file-viewer/jquery-full`, and `@file-viewer/svelte-full`.
 
-**Keep your existing Full package installed.** An optional renderer is an addition to the existing Full integration, not a replacement for it.
-
-For any optional renderer, use the package name and renderer export shown by its documentation or by the table above.
-
-#### Generic npm pattern
-
-The following is a template. Replace the placeholders with the real package and export names for the optional renderer you want to add:
+Keep the Full package installed, then add only the specialist renderer the application needs. The following example enables both published opt-ins; remove either package, import, and array entry when only one is needed:
 
 ```bash
-npm install <renderer-package>
+npm install @file-viewer/renderer-dicom @file-viewer/renderer-signature
 ```
-
-```ts
-import { <rendererExport> } from '<renderer-package>'
-
-const options = {
-  rendererMode: 'extend',
-  renderers: [<rendererExport>]
-}
-```
-
-`rendererMode:'extend'` is important when adding an optional renderer to an existing Full installation: it keeps the renderer baseline already supplied by the Full package and appends the new capability. Use `replace` only when you intentionally want the explicitly configured renderers to become the complete renderer set.
-
-If you need more than one optional renderer, install each required package and append each renderer export to the same `renderers` array.
-
-#### Real example: add DICOM to an existing Full package
-
-Install the optional DICOM renderer:
-
-```bash
-npm install @file-viewer/renderer-dicom
-```
-
-Register it without removing the Full renderer baseline:
 
 ```ts
 import { dicomRenderer } from '@file-viewer/renderer-dicom'
+import { signatureRenderer } from '@file-viewer/renderer-signature'
 
 const options = {
   rendererMode: 'extend',
-  renderers: [dicomRenderer]
+  renderers: [dicomRenderer, signatureRenderer]
 }
 ```
 
-The same pattern applies to other optional renderers: install the renderer package, import its renderer export, and append it with `rendererMode:'extend'`.
+`rendererMode: 'extend'` keeps the preset supplied by the Full package and appends these renderers. Use `replace` only when the explicitly configured renderers should become the complete set.
 
-#### Generic CLI pattern
+#### CLI-managed projects
 
-For a CLI-managed project, add the capability or one of its supported format tokens, then run the install step:
-
-```bash
-npx file-viewer-cli config add <capability-or-format> --write
-npx file-viewer-cli install --yes
-```
-
-For example, DICOM can be added with:
+Run one or both relevant `config add` commands, then install the resulting plan:
 
 ```bash
+# DICOM
 npx file-viewer-cli config add dicom --write
+
+# Digital-signature containers
+npx file-viewer-cli config add p7m --write
+
 npx file-viewer-cli install --yes
 ```
 
-The table above provides a working CLI selection for each currently documented optional renderer. `file-viewer-cli list` can also be used to inspect the capability catalog before changing a project.
+Use `npx file-viewer-cli list` to inspect the current catalog before changing a project.
 
-> Installing an `@file-viewer/*-full` package directly is not the same as selecting the CLI `full` profile. The historical Full packages keep their published compatibility closure and do not silently gain later specialist renderers. The CLI `full` profile intentionally combines the matching historical Full package with the later opt-in capabilities in the current CLI catalog.
+> Directly installing a Full package and selecting the CLI `full` profile are intentionally different. A Full package keeps the published `preset-all` compatibility baseline. The CLI `full` profile keeps that package and adds the current explicit opt-ins after presenting their weight and license boundaries.
 
 ### Using a prebuilt `web-full` browser bundle?
 
-The downloadable/prebuilt `web-full` IIFE bundle preserves the historical Full renderer set. Later optional specialist renderers are **not embedded automatically** in that prebuilt bundle.
+The downloadable `web-full` IIFE bundle contains the published Full renderer set. DICOM and digital-signature renderers are not embedded in that bundle.
 
-If you need an optional renderer that is not part of the historical bundle, use File Viewer from a package-manager project and install/register that renderer as shown above, or use the File Viewer CLI to generate the integration. Simply copying an optional renderer package next to the prebuilt bundle is not a substitute for registering it in the integration.
+Use a package-manager project or the File Viewer CLI when the integration needs an optional renderer. Copying a renderer package next to the prebuilt bundle does not register it.
 
-Some optional renderers can also delegate extracted or nested content to normal File Viewer renderers. Keep any required supporting renderer available when you want that nested preview. For example, the digital-signature renderer can pass safely extracted PDF, XML, image, Office, or other supported content back through the nested-renderer pipeline.
+The digital-signature renderer can pass safely extracted PDF, XML, image, Office, or other supported content back through the nested-renderer pipeline, so keep the matching normal renderer available when that preview is required. Cryptographic verification does not establish certificate or key trust, qualified-signature status, policy compliance, or legal validity.
 
 ## Renderer Package Reference
 
@@ -218,7 +186,7 @@ fileViewerRenderers({
 
 The default experience is intentionally zero-config: if the plugin receives no explicit `preset`, `formats`, or `renderers`, or only receives `copyAssets:true`, it auto-discovers installed `@file-viewer/preset-*` packages. `preset-all` takes precedence when present; otherwise installed `lite`, `office`, and `engineering` presets are composed.
 
-Install `@file-viewer/preset-all` when a heavy user wants the fastest compatibility-matrix setup. Later specialist capabilities such as DICOM and digital signatures remain explicit:
+Install `@file-viewer/preset-all` when an application needs the published compatibility baseline. DICOM and digital signatures remain explicit:
 
 ```bash
 npm install @file-viewer/vue3 @file-viewer/preset-all

--- a/docs/guide/on-demand-renderers.md
+++ b/docs/guide/on-demand-renderers.md
@@ -67,13 +67,47 @@ DICOM and digital-signature inspection are intentionally **opt-in** specialist c
 | **DICOM** (`@file-viewer/renderer-dicom`) | `.dcm`, `.dicom` | `npm install @file-viewer/renderer-dicom` | `npx file-viewer-cli config add dicom --write` | Local DICOM Part 10 single-frame and multi-frame images with frame navigation, window width/center, zoom, pan, 90° rotation, fit-to-view, and basic image metadata. It is a preview aid, not a diagnostic workstation. |
 | **Digital signatures** (`@file-viewer/renderer-signature`) | `.p7m`, `.p7s`, `.p7b`, `.p7c`, `.pkcs7`, `.cms`, `.cmsc`, `.tsq`, `.tsr`, `.tst`, `.tsd`, `.asics`, `.scs`, `.asice`, `.sce`, `.ers`, `.jws`, `.asc`, `.sig`, `.pgp`, `.gpg` | `npm install @file-viewer/renderer-signature` | `npx file-viewer-cli config add p7m --write` | Browser-local inspection of CMS/PKCS#7 and selected CAdES data, timestamps, ASiC containers, evidence records, JWS, and OpenPGP. It can show signers, certificates, algorithms, digest/signature verification results, timestamps, and safely extracted embedded documents. |
 
-After changing a CLI-managed project, install the selected capability packages and regenerate the integration:
+### I already use a Full package. How do I enable an optional renderer?
+
+The same rule applies to every historical Full package: `@file-viewer/web-full`, `@file-viewer/vue3-full`, `@file-viewer/vue2.7-full`, `@file-viewer/vue2.6-full`, `@file-viewer/react-full`, `@file-viewer/react-legacy-full`, `@file-viewer/jquery-full`, and `@file-viewer/svelte-full`.
+
+**Keep your existing Full package installed.** Do not replace it and do not switch away from the Full integration. Install only the optional renderer you need, then add it with `rendererMode:'extend'` so the existing Full renderer set remains available.
+
+#### Add DICOM
 
 ```bash
-npx file-viewer-cli install --yes
+npm install @file-viewer/renderer-dicom
 ```
 
-For a direct npm integration, explicitly register only the specialist renderers the application needs. Use `rendererMode:'extend'` when adding them to an existing Full/preset baseline so the already configured renderers remain available:
+```ts
+import { dicomRenderer } from '@file-viewer/renderer-dicom'
+
+const options = {
+  rendererMode: 'extend',
+  renderers: [dicomRenderer]
+}
+```
+
+#### Add digital-signature formats
+
+```bash
+npm install @file-viewer/renderer-signature
+```
+
+```ts
+import { signatureRenderer } from '@file-viewer/renderer-signature'
+
+const options = {
+  rendererMode: 'extend',
+  renderers: [signatureRenderer]
+}
+```
+
+#### Add both optional renderers
+
+```bash
+npm install @file-viewer/renderer-dicom @file-viewer/renderer-signature
+```
 
 ```ts
 import { dicomRenderer } from '@file-viewer/renderer-dicom'
@@ -85,9 +119,28 @@ const options = {
 }
 ```
 
-For example, a DICOM-only addition needs only `@file-viewer/renderer-dicom` and `dicomRenderer`; a signature-only addition needs only `@file-viewer/renderer-signature` and `signatureRenderer`.
+`rendererMode:'extend'` is important in these examples: it keeps the renderer baseline already provided by the Full package and appends the selected specialist renderer. Do not change an existing Full integration to a DICOM-only or signature-only `replace` configuration unless you intentionally want to remove the other Full capabilities.
+
+If the project is managed with the File Viewer CLI, select the optional capability and then run the install step:
+
+```bash
+# DICOM
+npx file-viewer-cli config add dicom --write
+
+# Digital signatures
+npx file-viewer-cli config add p7m --write
+
+# Install the selected capability packages and regenerate the integration
+npx file-viewer-cli install --yes
+```
 
 > Installing an `@file-viewer/*-full` package directly is not the same as selecting the CLI `full` profile. The historical Full packages keep their published compatibility closure and do not silently gain later specialist renderers. The CLI `full` profile intentionally combines the matching historical Full package with the later opt-in capabilities in the current CLI catalog.
+
+### Using a prebuilt `web-full` browser bundle?
+
+The downloadable/prebuilt `web-full` IIFE bundle preserves the historical Full renderer set. DICOM and digital-signature renderers are **not embedded** in that prebuilt bundle.
+
+If you need these specialist capabilities, use File Viewer from a package-manager project and install the optional renderer package as shown above, or use the File Viewer CLI to generate the integration. Simply downloading the historical `web-full` browser bundle does not enable DICOM or digital-signature formats, and copying an optional renderer package next to the bundle is not a substitute for registering it in the integration.
 
 For signature containers that contain an embedded PDF, XML, image, Office document, or another supported file, keep the corresponding normal renderer available as well so the safely extracted payload can continue through the nested-renderer pipeline. Signature parsing or cryptographic verification does not by itself establish certificate/key trust, qualified-signature status, policy compliance, or legal validity.
 

--- a/docs/guide/on-demand-renderers.md
+++ b/docs/guide/on-demand-renderers.md
@@ -58,6 +58,39 @@ The plugin reads the Vite major installed by the application. Vite 5–7 receive
 | `@file-viewer/preset-engineering` | CAD, EDA, Typst, archives, email, data, 3D, geo, drawing, and mind maps |
 | `@file-viewer/preset-all` | Admin workbenches that need the published compatibility renderer set; later specialist capabilities remain explicit |
 
+## Optional Specialist Renderers
+
+DICOM and digital-signature inspection are intentionally **opt-in** specialist capabilities. They are not installed automatically by the historical `@file-viewer/*-full` packages or by the frozen `@file-viewer/preset-all` compatibility matrix. This keeps upgrades from unexpectedly adding large medical-imaging or cryptographic dependencies.
+
+| Optional renderer | Formats | Direct npm install | CLI selection | What the viewer shows |
+| --- | --- | --- | --- | --- |
+| **DICOM** (`@file-viewer/renderer-dicom`) | `.dcm`, `.dicom` | `npm install @file-viewer/renderer-dicom` | `npx file-viewer-cli config add dicom --write` | Local DICOM Part 10 single-frame and multi-frame images with frame navigation, window width/center, zoom, pan, 90° rotation, fit-to-view, and basic image metadata. It is a preview aid, not a diagnostic workstation. |
+| **Digital signatures** (`@file-viewer/renderer-signature`) | `.p7m`, `.p7s`, `.p7b`, `.p7c`, `.pkcs7`, `.cms`, `.cmsc`, `.tsq`, `.tsr`, `.tst`, `.tsd`, `.asics`, `.scs`, `.asice`, `.sce`, `.ers`, `.jws`, `.asc`, `.sig`, `.pgp`, `.gpg` | `npm install @file-viewer/renderer-signature` | `npx file-viewer-cli config add p7m --write` | Browser-local inspection of CMS/PKCS#7 and selected CAdES data, timestamps, ASiC containers, evidence records, JWS, and OpenPGP. It can show signers, certificates, algorithms, digest/signature verification results, timestamps, and safely extracted embedded documents. |
+
+After changing a CLI-managed project, install the selected capability packages and regenerate the integration:
+
+```bash
+npx file-viewer-cli install --yes
+```
+
+For a direct npm integration, explicitly register only the specialist renderers the application needs. Use `rendererMode:'extend'` when adding them to an existing Full/preset baseline so the already configured renderers remain available:
+
+```ts
+import { dicomRenderer } from '@file-viewer/renderer-dicom'
+import { signatureRenderer } from '@file-viewer/renderer-signature'
+
+const options = {
+  rendererMode: 'extend',
+  renderers: [dicomRenderer, signatureRenderer]
+}
+```
+
+For example, a DICOM-only addition needs only `@file-viewer/renderer-dicom` and `dicomRenderer`; a signature-only addition needs only `@file-viewer/renderer-signature` and `signatureRenderer`.
+
+> Installing an `@file-viewer/*-full` package directly is not the same as selecting the CLI `full` profile. The historical Full packages keep their published compatibility closure and do not silently gain later specialist renderers. The CLI `full` profile intentionally combines the matching historical Full package with the later opt-in capabilities in the current CLI catalog.
+
+For signature containers that contain an embedded PDF, XML, image, Office document, or another supported file, keep the corresponding normal renderer available as well so the safely extracted payload can continue through the nested-renderer pipeline. Signature parsing or cryptographic verification does not by itself establish certificate/key trust, qualified-signature status, policy compliance, or legal validity.
+
 ## Renderer Package Reference
 
 Install a single renderer when a product needs the smallest possible capability set:
@@ -129,7 +162,7 @@ fileViewerRenderers({
 
 The default experience is intentionally zero-config: if the plugin receives no explicit `preset`, `formats`, or `renderers`, or only receives `copyAssets:true`, it auto-discovers installed `@file-viewer/preset-*` packages. `preset-all` takes precedence when present; otherwise installed `lite`, `office`, and `engineering` presets are composed.
 
-Install `@file-viewer/preset-all` when a heavy user wants the fastest full-capability setup:
+Install `@file-viewer/preset-all` when a heavy user wants the fastest compatibility-matrix setup. Later specialist capabilities such as DICOM and digital signatures remain explicit:
 
 ```bash
 npm install @file-viewer/vue3 @file-viewer/preset-all

--- a/docs/guide/on-demand-renderers.md
+++ b/docs/guide/on-demand-renderers.md
@@ -60,7 +60,9 @@ The plugin reads the Vite major installed by the application. Vite 5–7 receive
 
 ## Optional Specialist Renderers
 
-DICOM and digital-signature inspection are intentionally **opt-in** specialist capabilities. They are not installed automatically by the historical `@file-viewer/*-full` packages or by the frozen `@file-viewer/preset-all` compatibility matrix. This keeps upgrades from unexpectedly adding large medical-imaging or cryptographic dependencies.
+Some specialist capabilities are intentionally **opt-in**. Optional renderers are not installed automatically by the historical `@file-viewer/*-full` packages or by the frozen `@file-viewer/preset-all` compatibility matrix. This keeps existing upgrades stable and prevents large or specialized dependencies from being added unless an application explicitly asks for them.
+
+The table below lists the currently published optional specialist renderers:
 
 | Optional renderer | Formats | Direct npm install | CLI selection | What the viewer shows |
 | --- | --- | --- | --- | --- |
@@ -71,13 +73,40 @@ DICOM and digital-signature inspection are intentionally **opt-in** specialist c
 
 The same rule applies to every historical Full package: `@file-viewer/web-full`, `@file-viewer/vue3-full`, `@file-viewer/vue2.7-full`, `@file-viewer/vue2.6-full`, `@file-viewer/react-full`, `@file-viewer/react-legacy-full`, `@file-viewer/jquery-full`, and `@file-viewer/svelte-full`.
 
-**Keep your existing Full package installed.** Do not replace it and do not switch away from the Full integration. Install only the optional renderer you need, then add it with `rendererMode:'extend'` so the existing Full renderer set remains available.
+**Keep your existing Full package installed.** An optional renderer is an addition to the existing Full integration, not a replacement for it.
 
-#### Add DICOM
+For any optional renderer, use the package name and renderer export shown by its documentation or by the table above.
+
+#### Generic npm pattern
+
+The following is a template. Replace the placeholders with the real package and export names for the optional renderer you want to add:
+
+```bash
+npm install <renderer-package>
+```
+
+```ts
+import { <rendererExport> } from '<renderer-package>'
+
+const options = {
+  rendererMode: 'extend',
+  renderers: [<rendererExport>]
+}
+```
+
+`rendererMode:'extend'` is important when adding an optional renderer to an existing Full installation: it keeps the renderer baseline already supplied by the Full package and appends the new capability. Use `replace` only when you intentionally want the explicitly configured renderers to become the complete renderer set.
+
+If you need more than one optional renderer, install each required package and append each renderer export to the same `renderers` array.
+
+#### Real example: add DICOM to an existing Full package
+
+Install the optional DICOM renderer:
 
 ```bash
 npm install @file-viewer/renderer-dicom
 ```
+
+Register it without removing the Full renderer baseline:
 
 ```ts
 import { dicomRenderer } from '@file-viewer/renderer-dicom'
@@ -88,61 +117,35 @@ const options = {
 }
 ```
 
-#### Add digital-signature formats
+The same pattern applies to other optional renderers: install the renderer package, import its renderer export, and append it with `rendererMode:'extend'`.
+
+#### Generic CLI pattern
+
+For a CLI-managed project, add the capability or one of its supported format tokens, then run the install step:
 
 ```bash
-npm install @file-viewer/renderer-signature
-```
-
-```ts
-import { signatureRenderer } from '@file-viewer/renderer-signature'
-
-const options = {
-  rendererMode: 'extend',
-  renderers: [signatureRenderer]
-}
-```
-
-#### Add both optional renderers
-
-```bash
-npm install @file-viewer/renderer-dicom @file-viewer/renderer-signature
-```
-
-```ts
-import { dicomRenderer } from '@file-viewer/renderer-dicom'
-import { signatureRenderer } from '@file-viewer/renderer-signature'
-
-const options = {
-  rendererMode: 'extend',
-  renderers: [dicomRenderer, signatureRenderer]
-}
-```
-
-`rendererMode:'extend'` is important in these examples: it keeps the renderer baseline already provided by the Full package and appends the selected specialist renderer. Do not change an existing Full integration to a DICOM-only or signature-only `replace` configuration unless you intentionally want to remove the other Full capabilities.
-
-If the project is managed with the File Viewer CLI, select the optional capability and then run the install step:
-
-```bash
-# DICOM
-npx file-viewer-cli config add dicom --write
-
-# Digital signatures
-npx file-viewer-cli config add p7m --write
-
-# Install the selected capability packages and regenerate the integration
+npx file-viewer-cli config add <capability-or-format> --write
 npx file-viewer-cli install --yes
 ```
+
+For example, DICOM can be added with:
+
+```bash
+npx file-viewer-cli config add dicom --write
+npx file-viewer-cli install --yes
+```
+
+The table above provides a working CLI selection for each currently documented optional renderer. `file-viewer-cli list` can also be used to inspect the capability catalog before changing a project.
 
 > Installing an `@file-viewer/*-full` package directly is not the same as selecting the CLI `full` profile. The historical Full packages keep their published compatibility closure and do not silently gain later specialist renderers. The CLI `full` profile intentionally combines the matching historical Full package with the later opt-in capabilities in the current CLI catalog.
 
 ### Using a prebuilt `web-full` browser bundle?
 
-The downloadable/prebuilt `web-full` IIFE bundle preserves the historical Full renderer set. DICOM and digital-signature renderers are **not embedded** in that prebuilt bundle.
+The downloadable/prebuilt `web-full` IIFE bundle preserves the historical Full renderer set. Later optional specialist renderers are **not embedded automatically** in that prebuilt bundle.
 
-If you need these specialist capabilities, use File Viewer from a package-manager project and install the optional renderer package as shown above, or use the File Viewer CLI to generate the integration. Simply downloading the historical `web-full` browser bundle does not enable DICOM or digital-signature formats, and copying an optional renderer package next to the bundle is not a substitute for registering it in the integration.
+If you need an optional renderer that is not part of the historical bundle, use File Viewer from a package-manager project and install/register that renderer as shown above, or use the File Viewer CLI to generate the integration. Simply copying an optional renderer package next to the prebuilt bundle is not a substitute for registering it in the integration.
 
-For signature containers that contain an embedded PDF, XML, image, Office document, or another supported file, keep the corresponding normal renderer available as well so the safely extracted payload can continue through the nested-renderer pipeline. Signature parsing or cryptographic verification does not by itself establish certificate/key trust, qualified-signature status, policy compliance, or legal validity.
+Some optional renderers can also delegate extracted or nested content to normal File Viewer renderers. Keep any required supporting renderer available when you want that nested preview. For example, the digital-signature renderer can pass safely extracted PDF, XML, image, Office, or other supported content back through the nested-renderer pipeline.
 
 ## Renderer Package Reference
 

--- a/docs/zh/guide/on-demand-renderers.md
+++ b/docs/zh/guide/on-demand-renderers.md
@@ -63,6 +63,55 @@
 | `@file-viewer/preset-all`                                           | 已发布兼容 renderer 集合                                                                                   | 既有 demo 和全量发行版保持兼容；后续专业能力仍显式安装                                    |
 | `@file-viewer/vite-plugin`                                          | 自动生成 renderer virtual module、复制 assets、设置 manual chunks                                          | 让业务项目按配置自动装配，不需要手写大量 import                                           |
 
+## 可选专业 renderer
+
+DICOM 与数字签名检查是显式可选能力，不属于八个已发布 `@file-viewer/*-full` 包或 `@file-viewer/preset-all` 的依赖。这样普通升级不会额外引入医学影像或密码学重依赖，也不会改变 Full 包已经发布的能力边界。
+
+| 可选 renderer | 格式 | 直接安装 | CLI 选择 | 能力边界 |
+| --- | --- | --- | --- | --- |
+| **DICOM** (`@file-viewer/renderer-dicom`) | `.dcm`、`.dicom` | `npm install @file-viewer/renderer-dicom` | `npx file-viewer-cli config add dicom --write` | 预览一个本地 DICOM Part 10 文件，支持多帧导航、窗宽/窗位、缩放、拖动、旋转、适配视图和基础元数据；不负责 study 组装、PACS/DICOMweb、MPR、分割或诊断。 |
+| **数字签名** (`@file-viewer/renderer-signature`) | `.p7m`、`.p7s`、`.p7c`、`.p7b`、`.pkcs7`、`.cms`、`.cmsc`、`.tsd`、`.tst`、`.tsq`、`.tsr`、`.asics`、`.scs`、`.asice`、`.sce`、`.ers`、`.asc`、`.sig`、`.pgp`、`.gpg`、`.jws` | `npm install @file-viewer/renderer-signature` | `npx file-viewer-cli config add p7m --write` | 在浏览器本地做有界容器检查，并分开报告解析、摘要、签名和时间戳结果。 |
+
+### 已经使用 Full 包时
+
+这条规则适用于 `@file-viewer/web-full`、`@file-viewer/vue3-full`、`@file-viewer/vue2.7-full`、`@file-viewer/vue2.6-full`、`@file-viewer/react-full`、`@file-viewer/react-legacy-full`、`@file-viewer/jquery-full` 和 `@file-viewer/svelte-full`。
+
+保留现有 Full 包，只安装业务真正需要的专业 renderer。下面示例同时启用两个当前可选能力；只需要其中一个时，删除另一项安装、import 和数组成员即可：
+
+```bash
+npm install @file-viewer/renderer-dicom @file-viewer/renderer-signature
+```
+
+```ts
+import { dicomRenderer } from '@file-viewer/renderer-dicom'
+import { signatureRenderer } from '@file-viewer/renderer-signature'
+
+const options = {
+  rendererMode: 'extend',
+  renderers: [dicomRenderer, signatureRenderer]
+}
+```
+
+`rendererMode: 'extend'` 会保留 Full 包提供的 preset，再追加上述 renderer。只有明确希望显式配置成为完整 renderer 集合时，才使用 `replace`。
+
+CLI 管理的项目执行一个或两个需要的 `config add`，再安装生成的方案：
+
+```bash
+# DICOM
+npx file-viewer-cli config add dicom --write
+
+# 数字签名容器
+npx file-viewer-cli config add p7m --write
+
+npx file-viewer-cli install --yes
+```
+
+直接安装 Full 包与选择 CLI `full` profile 是两个有意区分的入口：Full 包保持已发布的 `preset-all` 兼容基线；CLI `full` 保留对应 Full 包，并在展示体积与许可证边界后加入当前显式可选能力。
+
+预构建 `web-full` IIFE 只包含已发布的 Full renderer 集合，不内置 DICOM 与数字签名 renderer。需要这些能力时，应使用包管理项目或 CLI 生成集成；把可选包复制到 IIFE 旁边并不会完成注册。
+
+数字签名 renderer 可以把安全提取出的 PDF、XML、图片、Office 等内容交回普通嵌套预览链路，因此需要同时保留对应 renderer。密码学验证结果不等于证书或密钥可信，也不能判定合格签名、政策合规或法律效力。
+
 ## 用户最佳体验路径
 
 | 场景                            | 推荐方式                                                  | 安装体验                        | 打包体验                                 |


### PR DESCRIPTION
## Summary

- Document that the eight Full packages and `@file-viewer/preset-all` keep their published compatibility baseline while DICOM and digital-signature inspection remain explicit opt-ins.
- Replace placeholder snippets with runnable npm and CLI examples using `rendererMode: 'extend'`.
- State the DICOM, signature-trust, nested-preview, CLI `full`, and prebuilt `web-full` boundaries precisely.
- Keep the English and Chinese guides aligned.

## Related issue

N/A: focused documentation clarification for the published 3.0 package boundary.

## Change classification

- [ ] User-visible UI or rendering change
- [x] Non-visual change
- [ ] File-format or renderer behavior
- [ ] Public API, package, Worker, WASM, or deployment-path change

## Verification

| Check | Result |
| --- | --- |
| `pnpm docs:build` | Pass |
| `pnpm install --frozen-lockfile --offline` | Pass |

## Sample / fixture evidence

- N/A: documentation-only change; no file-format behavior changed.

## Visual evidence

- N/A: documentation-only change; no rendered UI changed.

## Risk and compatibility

- Affected packages/formats: English and Chinese modular-renderer guidance for Full packages, DICOM, digital signatures, the CLI, and the prebuilt `web-full` bundle.
- Compatibility or migration risk: No runtime or package behavior changes; the examples reflect the current 3.0 manifests and CLI catalog.
- Rollback: Revert the documentation commits.

## Checklist

- [x] I added or updated focused automated coverage, or explained why it is not needed.
- [x] I updated user-facing documentation or release notes when behavior or API changed, or marked them not applicable.
- [x] I verified offline/private-deployment paths when changing Worker, WASM, fonts, vendor assets, or URLs.
- [x] I did not commit secrets, customer files, private samples, generated caches, or unrelated changes.
