### PR TITLE
fix(cli): harden quickstart runtime and add interactive format selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 完整对外更新日志见 [docs/changelog.md](docs/changelog.md)。
 
+## Unreleased
+
+### CLI reliability and interaction
+
+- 新建项目的交互式格式选择改为预先列出 renderer/格式族并显示勾选状态；当前 profile 已包含的能力保持启用，额外能力支持编号、范围、全选和清空，不再要求手写扩展名。
+- Vite 8 脚手架声明并在 `dev`/`build` 前校验 Node `^20.19.0 || >=22.12.0`，旧运行时会获得明确迁移提示；Web Component 事件从元素所属 document realm 创建，并为缺失全局 `CustomEvent` 的 DOM 环境保留兼容回退。
+
 ## File Viewer v3.0.0 — 2026-08-27
 
 这是模块化安装、全功能 CLI、专业格式按需加载和全仓安全加固的主版本。已发布 Full 包的格式、API 和离线资源契约保持向下兼容；DICOM 和数字签名等后续重型能力仍为显式按需安装。

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,11 @@
   The notable user-facing changes shipped from the current File Viewer mainline. GitHub Releases remains the source for downloadable artifacts and immutable release notes.
 </p>
 
+## Unreleased — CLI reliability and interaction
+
+- Replaced free-form format/capability entry in the interactive create/add wizard with checkbox-style renderer and format-family rows. Capabilities included by the selected profile are visibly preselected and retained, while optional rows support individual numbers, ranges, select-all, and clear-extra commands.
+- Generated Vite 8 projects now declare and preflight Node `^20.19.0 || >=22.12.0` before `dev` or `build`, producing an actionable upgrade message on unsupported runtimes. Web Component events are created from the element's owning document realm with a compatibility fallback when global `CustomEvent` is unavailable.
+
 ## v3.0.0 — Modular CLI, opt-in specialist formats, and security gates
 
 Released August 27, 2026.

--- a/docs/public/images/cli-capability-selector.svg
+++ b/docs/public/images/cli-capability-selector.svg
@@ -1,0 +1,33 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1240" height="720" viewBox="0 0 1240 720" role="img" aria-labelledby="title desc">
+  <title id="title">File Viewer CLI capability selector</title>
+  <desc id="desc">Terminal preview of the interactive checkbox-style file format family selector.</desc>
+  <rect width="1240" height="720" rx="28" fill="#0b1020"/>
+  <rect x="32" y="32" width="1176" height="656" rx="20" fill="#111827" stroke="#26334d"/>
+  <circle cx="72" cy="72" r="8" fill="#fb7185"/>
+  <circle cx="100" cy="72" r="8" fill="#fbbf24"/>
+  <circle cx="128" cy="72" r="8" fill="#34d399"/>
+  <text x="620" y="79" text-anchor="middle" fill="#94a3b8" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="18">file-viewer create</text>
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="22">
+    <text x="72" y="132" fill="#e2e8f0">文件格式族:</text>
+    <text x="72" y="184" fill="#86efac">[✓]  1. PDF</text>
+    <text x="398" y="184" fill="#cbd5e1">.pdf</text>
+    <text x="850" y="184" fill="#64748b">(方案内置)</text>
+    <text x="72" y="228" fill="#86efac">[✓]  2. Office Word OpenXML</text>
+    <text x="398" y="228" fill="#cbd5e1">.docx .dotx .docm</text>
+    <text x="850" y="228" fill="#64748b">(方案内置)</text>
+    <text x="72" y="272" fill="#e2e8f0">[ ]  3. CAD</text>
+    <text x="398" y="272" fill="#cbd5e1">.dwg .dxf .dwf</text>
+    <text x="850" y="272" fill="#fbbf24">(重型)</text>
+    <text x="72" y="316" fill="#60a5fa">[x]  4. DICOM</text>
+    <text x="398" y="316" fill="#cbd5e1">.dcm .dicom</text>
+    <text x="850" y="316" fill="#fbbf24">(重型)</text>
+    <text x="72" y="360" fill="#e2e8f0">[ ]  5. Archive</text>
+    <text x="398" y="360" fill="#cbd5e1">.zip .rar .7z +4</text>
+    <text x="72" y="422" fill="#94a3b8">已启用 3/5 项，其中 2 项由当前方案提供</text>
+    <text x="72" y="484" fill="#cbd5e1">输入编号/范围切换（如 2,5-7）；a=全选，n=清空额外项，</text>
+    <text x="72" y="524" fill="#cbd5e1">b=返回，0=取消，回车=确认：</text>
+    <text x="706" y="524" fill="#60a5fa">3,5</text>
+    <rect x="762" y="501" width="13" height="27" fill="#e2e8f0"/>
+    <text x="72" y="600" fill="#64748b">方案内能力预先勾选并保持启用；额外格式可按编号或范围切换。</text>
+  </g>
+</svg>

--- a/packages/components/web/package.json
+++ b/packages/components/web/package.json
@@ -61,7 +61,8 @@
     "README.en.md"
   ],
   "scripts": {
-    "build": "tsc -b tsconfig.json && node scripts/build-iife.mjs",
+    "build": "tsc -b tsconfig.json && node scripts/build-iife.mjs && node --test test/*.test.mjs",
+    "test": "node --test test/*.test.mjs",
     "type-check": "tsc -b tsconfig.json"
   },
   "dependencies": {

--- a/packages/components/web/src/custom-event.ts
+++ b/packages/components/web/src/custom-event.ts
@@ -1,0 +1,55 @@
+export type FileViewerCustomEventOwner = {
+  ownerDocument?: Document | null;
+};
+
+export function createFileViewerCustomEvent<Detail>(
+  owner: FileViewerCustomEventOwner,
+  name: string,
+  detail: Detail
+): CustomEvent<Detail> {
+  const init: CustomEventInit<Detail> = {
+    bubbles: true,
+    composed: true,
+    detail,
+  };
+  const ownerWindow = owner.ownerDocument?.defaultView;
+  const ownerCustomEvent = ownerWindow?.CustomEvent;
+  const CustomEventConstructor =
+    typeof ownerCustomEvent === 'function'
+      ? ownerCustomEvent
+      : typeof globalThis.CustomEvent === 'function'
+        ? globalThis.CustomEvent
+        : undefined;
+  if (CustomEventConstructor) {
+    return new CustomEventConstructor(name, init) as CustomEvent<Detail>;
+  }
+
+  const ownerDocument = owner.ownerDocument;
+  if (ownerDocument && typeof ownerDocument.createEvent === 'function') {
+    try {
+      const legacyEvent = ownerDocument.createEvent('CustomEvent') as CustomEvent<Detail>;
+      legacyEvent.initCustomEvent(name, true, false, detail);
+      return legacyEvent;
+    } catch {
+      // Fall through to the standard Event constructor for partial DOM shims.
+    }
+  }
+
+  const ownerEvent = ownerWindow?.Event;
+  const EventConstructor =
+    typeof ownerEvent === 'function'
+      ? ownerEvent
+      : typeof globalThis.Event === 'function'
+        ? globalThis.Event
+        : undefined;
+  if (!EventConstructor) {
+    throw new Error(`Cannot dispatch ${name}: this runtime does not provide an Event constructor.`);
+  }
+  const event = new EventConstructor(name, { bubbles: true, composed: true }) as CustomEvent<Detail>;
+  Object.defineProperty(event, 'detail', {
+    configurable: false,
+    enumerable: true,
+    value: detail,
+  });
+  return event;
+}

--- a/packages/components/web/src/element.ts
+++ b/packages/components/web/src/element.ts
@@ -1,6 +1,7 @@
 import {
   fileViewerCoreRendererRegistry,
 } from '@file-viewer/core';
+import { createFileViewerCustomEvent } from './custom-event.js';
 import {
   mountViewer as mountCoreViewer,
   type FileRef,
@@ -708,11 +709,7 @@ export class FileViewerElement extends ElementBase implements ViewerControllerHa
   }
 
   private dispatchTypedEvent<Detail>(name: string, detail: Detail): void {
-    this.dispatchEvent(new CustomEvent(name, {
-      bubbles: true,
-      composed: true,
-      detail,
-    }));
+    this.dispatchEvent(createFileViewerCustomEvent(this, name, detail));
   }
 }
 

--- a/packages/components/web/test/custom-event.test.mjs
+++ b/packages/components/web/test/custom-event.test.mjs
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { createFileViewerCustomEvent } from '../dist/custom-event.js'
+
+test('uses the owning document realm CustomEvent constructor', () => {
+  class RealmCustomEvent {
+    constructor(type, init) {
+      this.type = type
+      Object.assign(this, init)
+    }
+  }
+  const event = createFileViewerCustomEvent(
+    { ownerDocument: { defaultView: { CustomEvent: RealmCustomEvent } } },
+    'viewer-ready',
+    { ready: true }
+  )
+  assert.equal(event.constructor, RealmCustomEvent)
+  assert.equal(event.type, 'viewer-ready')
+  assert.deepEqual(event.detail, { ready: true })
+  assert.equal(event.bubbles, true)
+  assert.equal(event.composed, true)
+})
+
+test('falls back to document.createEvent when realm and global constructors are unavailable', () => {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, 'CustomEvent')
+  Object.defineProperty(globalThis, 'CustomEvent', {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  })
+  try {
+    const legacyEvent = {
+      initCustomEvent(type, bubbles, cancelable, detail) {
+        Object.assign(this, { type, bubbles, cancelable, detail })
+      },
+    }
+    const event = createFileViewerCustomEvent(
+      {
+        ownerDocument: {
+          defaultView: { CustomEvent: {} },
+          createEvent(type) {
+            assert.equal(type, 'CustomEvent')
+            return legacyEvent
+          },
+        },
+      },
+      'viewer-error',
+      { message: 'boom' }
+    )
+    assert.equal(event, legacyEvent)
+    assert.equal(event.type, 'viewer-error')
+    assert.equal(event.bubbles, true)
+    assert.equal(event.cancelable, false)
+    assert.deepEqual(event.detail, { message: 'boom' })
+  } finally {
+    if (descriptor) Object.defineProperty(globalThis, 'CustomEvent', descriptor)
+    else delete globalThis.CustomEvent
+  }
+})

--- a/packages/tools/cli/README.en.md
+++ b/packages/tools/cli/README.en.md
@@ -22,7 +22,9 @@ npx file-viewer-cli@latest add .
 
 `file-viewer-cli` is the single-bin `npx` carrier and pins this scoped package at the same version. If `@file-viewer/cli` is already installed locally, run `file-viewer add .` instead.
 
-The wizard selects a framework and validated version, File Viewer release, profile, formats, package manager, and asset directory. It supports Vanilla/Web Component, Vue 3, Vue 2.7, Vue 2.6, React, React Legacy, Svelte, and jQuery.
+The wizard selects a framework and validated version, File Viewer release, profile, formats, package manager, and asset directory. Interactive runs present checkbox-style renderer/format-family rows, preselect and retain everything supplied by the chosen profile, and let users toggle optional capabilities by number or range instead of typing extensions. It supports Vanilla/Web Component, Vue 3, Vue 2.7, Vue 2.6, React, React Legacy, Svelte, and jQuery.
+
+New projects use Vite 8. The generated `package.json` declares Node `^20.19.0 || >=22.12.0`, and `dev`/`build` run a version preflight. Unsupported runtimes therefore fail with an actionable upgrade-and-reinstall message instead of an indirect `CustomEvent` exception.
 
 ```bash
 npx file-viewer-cli create my-viewer \

--- a/packages/tools/cli/README.md
+++ b/packages/tools/cli/README.md
@@ -22,7 +22,9 @@ npx file-viewer-cli@latest add .
 
 `file-viewer-cli` 是便于 `npx` 自动选择命令的单 bin 入口，并严格依赖同版本的本 scoped 包。项目已经安装 `@file-viewer/cli` 时，直接运行 `file-viewer add .`。
 
-向导可选择框架及其已校验版本、File Viewer 版本、profile、格式、包管理器和资源目录。支持 Vanilla/Web Component、Vue 3、Vue 2.7、Vue 2.6、React、React Legacy、Svelte 和 jQuery。
+向导可选择框架及其已校验版本、File Viewer 版本、profile、格式、包管理器和资源目录。交互模式会按 renderer/格式族列出复选项，profile 已包含的能力预先打勾并保持启用；额外能力可用单个编号或范围切换，无需手写扩展名。支持 Vanilla/Web Component、Vue 3、Vue 2.7、Vue 2.6、React、React Legacy、Svelte 和 jQuery。
+
+新建项目使用 Vite 8。生成的 `package.json` 会声明 Node `^20.19.0 || >=22.12.0`，并在 `dev`/`build` 前执行版本检查；不兼容环境会直接给出升级和重新安装依赖的操作提示，而不是以间接的 `CustomEvent` 异常失败。
 
 ```bash
 npx file-viewer-cli create my-viewer \

--- a/packages/tools/cli/src/cli.ts
+++ b/packages/tools/cli/src/cli.ts
@@ -27,6 +27,7 @@ import {
   createFileViewerRegistryEnvironment,
   detectYarnGeneration
 } from './carrier-command.js'
+import { promptFileViewerCapabilitySelection } from './interactive-selection.js'
 import {
   DEFAULT_FILE_VIEWER_CONFIG,
   createFileViewerInstallPlan,
@@ -52,6 +53,7 @@ import {
   resolveFileViewerOfflinePackages
 } from './index.js'
 import type {
+  FileViewerCliCatalog,
   FileViewerCliLocale,
   FileViewerFramework,
   FileViewerInstallSource,
@@ -1470,13 +1472,8 @@ async function promptQuickstart(
       'jquery'
     ] as const
     const profiles = ['standard', 'lite', 'office', 'engineering', 'all', 'full', 'custom'] as const
-    const fullCatalog = JSON.parse(
-      await readFile(new URL('../catalog/catalog.json', import.meta.url), 'utf8')
-    ) as {
-      frameworkTemplates: Record<
-        string,
-        { defaultVersion: string; validatedVersions: Record<string, unknown> }
-      >
+    const fullCatalog = (await loadFileViewerCliCatalog()) as FileViewerCliCatalog & {
+      frameworkTemplates: NonNullable<FileViewerCliCatalog['frameworkTemplates']>
     }
     let framework = args.framework ?? inspection?.framework ?? 'web'
     let profile = args.profile ?? inspection?.detectedProfile ?? 'standard'
@@ -1596,23 +1593,28 @@ async function promptQuickstart(
         }
         packageManagerVersion = value
       } else if (step === 6) {
-        const value = await askText(messages[args.locale].formats, formats)
+        const value = await promptFileViewerCapabilitySelection({
+          catalog: fullCatalog,
+          profile,
+          locale: args.locale,
+          formats: formats ? [formats] : [],
+          capabilities: capabilities ? [capabilities] : [],
+          question: (prompt) => io.question(prompt),
+          write: (output) => process.stdout.write(output)
+        })
         if (value === null) {
-          step -= 1
+          step = packageManager === 'yarn' ? 5 : 4
           continue
         }
-        formats = value === '-' ? '' : value
+        formats = value.formats.join(',')
+        capabilities = value.capabilities.join(',')
       } else if (step === 7) {
-        const value = await askText(messages[args.locale].capabilities, capabilities)
-        if (value === null) {
-          step -= 1
-          continue
-        }
-        capabilities = value === '-' ? '' : value
+        step += 1
+        continue
       } else if (step === 8) {
         const value = await askText(messages[args.locale].assetTarget, assetTarget, false)
         if (value === null) {
-          step -= 1
+          step = 6
           continue
         }
         assetTarget = value

--- a/packages/tools/cli/src/index.ts
+++ b/packages/tools/cli/src/index.ts
@@ -1360,6 +1360,22 @@ function selectQuickstartSample(
   }
 }
 
+const quickstartNodeEngine = '^20.19.0 || >=22.12.0'
+const quickstartNodeGuard = `const [major, minor] = process.versions.node.split('.').map(Number)
+const supported =
+  (major === 20 && minor >= 19) ||
+  (major === 22 && minor >= 12) ||
+  major > 22
+if (!supported) {
+  console.error(
+    'File Viewer quickstart uses Vite 8 and requires Node ${quickstartNodeEngine}; current ' +
+      process.version +
+      '. Upgrade Node, remove node_modules, and reinstall dependencies.'
+  )
+  process.exit(1)
+}
+`
+
 export async function scaffoldFileViewerQuickstart(
   projectRoot: string,
   input: Partial<FileViewerProjectConfig>,
@@ -1431,7 +1447,11 @@ export async function scaffoldFileViewerQuickstart(
           ...(config.packageManager && config.packageManagerVersion
             ? { packageManager: `${config.packageManager}@${config.packageManagerVersion}` }
             : {}),
-          scripts: { dev: 'vite', build: 'vite build' },
+          scripts: {
+            dev: 'node ./scripts/check-node.mjs && vite',
+            build: 'node ./scripts/check-node.mjs && vite build'
+          },
+          engines: { node: quickstartNodeEngine },
           dependencies: selectedTemplate.runtimeDependencies,
           devDependencies
         },
@@ -1439,6 +1459,7 @@ export async function scaffoldFileViewerQuickstart(
         2
       )}\n`
     ],
+    ['scripts/check-node.mjs', quickstartNodeGuard],
     [
       'index.html',
       '<!doctype html><html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"><title>File Viewer</title></head><body style="margin:0"><div id="app" style="height:100vh"></div><script type="module" src="/src/main.mjs"></script></body></html>\n'

--- a/packages/tools/cli/src/interactive-selection.ts
+++ b/packages/tools/cli/src/interactive-selection.ts
@@ -1,0 +1,343 @@
+import type {
+  FileViewerCapabilityCatalogEntry,
+  FileViewerCliCatalog,
+  FileViewerCliLocale,
+  FileViewerProfile,
+} from './types.js'
+
+export type FileViewerSelectionGroup = 'formats' | 'enhancements'
+
+type SelectionCopy = {
+  formats: string
+  enhancements: string
+  profile: string
+  heavy: string
+  review: string
+  noFormats: string
+  summary: (selected: number, total: number, inherited: number) => string
+  prompt: string
+  invalid: string
+  locked: string
+  cancelled: string
+}
+
+const selectionCopy: Record<FileViewerCliLocale, SelectionCopy> = {
+  en: {
+    formats: 'File format families',
+    enhancements: 'Optional capabilities without a file extension',
+    profile: 'profile',
+    heavy: 'heavy',
+    review: 'license review',
+    noFormats: 'no extension',
+    summary: (selected, total, inherited) =>
+      `${selected}/${total} enabled; ${inherited} provided by the selected profile`,
+    prompt:
+      'Toggle numbers/ranges (for example 2,5-7); a=all, n=clear extras, b=back, 0=cancel, Enter=confirm: ',
+    invalid: 'Enter listed numbers, ranges, a, n, b, 0, or press Enter.',
+    locked: 'Profile-provided capabilities stay enabled; only optional rows were changed.',
+    cancelled: 'Cancelled without changes.',
+  },
+  'zh-CN': {
+    formats: '文件格式族',
+    enhancements: '无扩展名的可选增强能力',
+    profile: '方案内置',
+    heavy: '重型',
+    review: '需关注许可证',
+    noFormats: '无扩展名',
+    summary: (selected, total, inherited) =>
+      `已启用 ${selected}/${total} 项，其中 ${inherited} 项由当前方案提供`,
+    prompt: '输入编号/范围切换（如 2,5-7）；a=全选，n=清空额外项，b=返回，0=取消，回车=确认：',
+    invalid: '请输入列表中的编号、范围、a、n、b、0，或直接回车确认。',
+    locked: '方案内置能力会保持启用，仅切换了可选项。',
+    cancelled: '已取消，未修改文件。',
+  },
+  'ja-JP': {
+    formats: 'ファイル形式ファミリー',
+    enhancements: '拡張子を持たないオプション機能',
+    profile: 'プロファイル',
+    heavy: '重量',
+    review: 'ライセンス確認',
+    noFormats: '拡張子なし',
+    summary: (selected, total, inherited) =>
+      `${selected}/${total} 件を有効化（${inherited} 件はプロファイルに含まれます）`,
+    prompt:
+      '番号/範囲を切替（例: 2,5-7）；a=すべて、n=追加分を解除、b=戻る、0=中止、Enter=確定: ',
+    invalid: '表示された番号、範囲、a、n、b、0 を入力するか、Enter で確定してください。',
+    locked: 'プロファイルに含まれる機能は有効のままです。オプション項目だけを切り替えました。',
+    cancelled: '変更せずにキャンセルしました。',
+  },
+  'de-DE': {
+    formats: 'Dateiformat-Familien',
+    enhancements: 'Optionale Funktionen ohne Dateiendung',
+    profile: 'Profil',
+    heavy: 'umfangreich',
+    review: 'Lizenz prüfen',
+    noFormats: 'keine Endung',
+    summary: (selected, total, inherited) =>
+      `${selected}/${total} aktiviert; ${inherited} durch das Profil bereitgestellt`,
+    prompt:
+      'Nummern/Bereiche umschalten (z. B. 2,5-7); a=alle, n=Extras leeren, b=zurück, 0=abbrechen, Enter=bestätigen: ',
+    invalid: 'Geben Sie Nummern, Bereiche, a, n, b oder 0 ein, oder bestätigen Sie mit Enter.',
+    locked: 'Profil-Funktionen bleiben aktiviert; nur optionale Einträge wurden geändert.',
+    cancelled: 'Ohne Änderungen abgebrochen.',
+  },
+}
+
+const normalizeTokens = (values: readonly string[]) =>
+  [
+    ...new Set(
+      values
+        .flatMap((value) => value.split(','))
+        .map((value) => value.trim().toLowerCase().replace(/^\./, ''))
+        .filter(Boolean)
+    ),
+  ]
+
+const capabilityForToken = (token: string, catalog: FileViewerCliCatalog) =>
+  catalog.capabilities.find(
+    (capability) =>
+      capability.id.toLowerCase() === token ||
+      capability.formats.some((format) => format.toLowerCase() === token) ||
+      capability.rendererIds.some((rendererId) => rendererId.toLowerCase() === token)
+  )
+
+const profileCapabilityIds = (profile: FileViewerProfile, catalog: FileViewerCliCatalog) => {
+  if (profile === 'custom') return new Set<string>()
+  if (profile === 'full') {
+    const excluded = new Set(catalog.legacyFull?.excludedFutureCapabilities ?? [])
+    return new Set(
+      catalog.capabilities
+        .filter((capability) => !excluded.has(capability.id))
+        .map((capability) => capability.id)
+    )
+  }
+  const selectedProfile = catalog.profiles.find((candidate) => candidate.id === profile)
+  const packages = new Set(selectedProfile?.capabilityPackages ?? [])
+  return new Set(
+    catalog.capabilities
+      .filter((capability) => packages.has(capability.packageName))
+      .map((capability) => capability.id)
+  )
+}
+
+export type FileViewerCapabilitySelectionState = {
+  catalog: FileViewerCliCatalog
+  profile: FileViewerProfile
+  selectedCapabilityIds: Set<string>
+  inheritedCapabilityIds: Set<string>
+  unknownFormats: string[]
+  unknownCapabilities: string[]
+}
+
+export function createFileViewerCapabilitySelection(input: {
+  catalog: FileViewerCliCatalog
+  profile: FileViewerProfile
+  formats?: readonly string[]
+  capabilities?: readonly string[]
+}): FileViewerCapabilitySelectionState {
+  const formats = normalizeTokens(input.formats ?? [])
+  const capabilities = normalizeTokens(input.capabilities ?? [])
+  const inheritedCapabilityIds = profileCapabilityIds(input.profile, input.catalog)
+  const selectedCapabilityIds = new Set<string>()
+  const unknownFormats: string[] = []
+  const unknownCapabilities: string[] = []
+  for (const token of formats) {
+    const capability = capabilityForToken(token, input.catalog)
+    if (capability) selectedCapabilityIds.add(capability.id)
+    else unknownFormats.push(token)
+  }
+  for (const token of capabilities) {
+    const capability = capabilityForToken(token, input.catalog)
+    if (capability) selectedCapabilityIds.add(capability.id)
+    else unknownCapabilities.push(token)
+  }
+  for (const capabilityId of inheritedCapabilityIds) selectedCapabilityIds.delete(capabilityId)
+  return {
+    catalog: input.catalog,
+    profile: input.profile,
+    selectedCapabilityIds,
+    inheritedCapabilityIds,
+    unknownFormats,
+    unknownCapabilities,
+  }
+}
+
+export type FileViewerCapabilitySelectionRow = {
+  index: number
+  capability: FileViewerCapabilityCatalogEntry
+  selected: boolean
+  locked: boolean
+}
+
+export function listFileViewerCapabilitySelectionRows(
+  state: FileViewerCapabilitySelectionState,
+  group: FileViewerSelectionGroup
+): FileViewerCapabilitySelectionRow[] {
+  return state.catalog.capabilities
+    .filter((capability) =>
+      group === 'formats' ? capability.formats.length > 0 : capability.formats.length === 0
+    )
+    .map((capability, index) => ({
+      index: index + 1,
+      capability,
+      selected:
+        state.inheritedCapabilityIds.has(capability.id) ||
+        state.selectedCapabilityIds.has(capability.id),
+      locked: state.inheritedCapabilityIds.has(capability.id),
+    }))
+}
+
+const acronyms = new Map<string, string>([
+  ['cad', 'CAD'],
+  ['dicom', 'DICOM'],
+  ['eda', 'EDA'],
+  ['epub', 'EPUB'],
+  ['html', 'HTML'],
+  ['iwork', 'iWork'],
+  ['ofd', 'OFD'],
+  ['openxml', 'OpenXML'],
+  ['pdf', 'PDF'],
+  ['ppt', 'PPT'],
+  ['pptx', 'PPTX'],
+  ['rtf', 'RTF'],
+  ['wasm', 'WASM'],
+  ['xmind', 'XMind'],
+  ['xml', 'XML'],
+])
+
+const capabilityLabel = (id: string) =>
+  id
+    .split('-')
+    .map((word) => acronyms.get(word) ?? `${word.slice(0, 1).toUpperCase()}${word.slice(1)}`)
+    .join(' ')
+
+const formatSummary = (capability: FileViewerCapabilityCatalogEntry, copy: SelectionCopy) => {
+  if (!capability.formats.length) return copy.noFormats
+  const visible = capability.formats.slice(0, 7).map((format) => `.${format}`)
+  const remainder = capability.formats.length - visible.length
+  return `${visible.join(' ')}${remainder > 0 ? ` +${remainder}` : ''}`
+}
+
+export function renderFileViewerSelectionGroup(
+  state: FileViewerCapabilitySelectionState,
+  group: FileViewerSelectionGroup,
+  locale: FileViewerCliLocale
+) {
+  const copy = selectionCopy[locale]
+  const rows = listFileViewerCapabilitySelectionRows(state, group)
+  const inherited = rows.filter((row) => row.locked).length
+  const selected = rows.filter((row) => row.selected).length
+  const labelWidth = Math.min(
+    34,
+    Math.max(18, ...rows.map((row) => capabilityLabel(row.capability.id).length))
+  )
+  const lines = rows.map((row) => {
+    const marker = row.locked ? '[✓]' : row.selected ? '[x]' : '[ ]'
+    const index = String(row.index).padStart(2, ' ')
+    const label = capabilityLabel(row.capability.id).padEnd(labelWidth, ' ')
+    const tags = [
+      row.locked ? copy.profile : '',
+      row.capability.weight === 'heavy' ? copy.heavy : '',
+      row.capability.license.policy !== 'permissive' ? copy.review : '',
+    ].filter(Boolean)
+    return `  ${marker} ${index}. ${label}  ${formatSummary(row.capability, copy)}${tags.length ? `  (${tags.join(', ')})` : ''}`
+  })
+  return `\n${group === 'formats' ? copy.formats : copy.enhancements}:\n${lines.join('\n')}\n  ${copy.summary(selected, rows.length, inherited)}\n`
+}
+
+type SelectionCommandResult =
+  | { action: 'confirm' | 'back' | 'cancel'; changed: false; locked: false }
+  | { action: 'changed'; changed: true; locked: boolean }
+  | { action: 'invalid'; changed: false; locked: false }
+
+export function applyFileViewerSelectionCommand(
+  state: FileViewerCapabilitySelectionState,
+  group: FileViewerSelectionGroup,
+  answer: string
+): SelectionCommandResult {
+  const normalized = answer.trim().toLowerCase()
+  if (!normalized) return { action: 'confirm', changed: false, locked: false }
+  if (normalized === 'b') return { action: 'back', changed: false, locked: false }
+  if (normalized === '0') return { action: 'cancel', changed: false, locked: false }
+  const rows = listFileViewerCapabilitySelectionRows(state, group)
+  const editable = rows.filter((row) => !row.locked)
+  if (normalized === 'a') {
+    for (const row of editable) state.selectedCapabilityIds.add(row.capability.id)
+    return { action: 'changed', changed: true, locked: false }
+  }
+  if (normalized === 'n') {
+    for (const row of editable) state.selectedCapabilityIds.delete(row.capability.id)
+    return { action: 'changed', changed: true, locked: false }
+  }
+  const indexes = new Set<number>()
+  for (const token of normalized.split(/[\s,]+/).filter(Boolean)) {
+    const match = token.match(/^(\d+)(?:-(\d+))?$/)
+    if (!match) return { action: 'invalid', changed: false, locked: false }
+    const start = Number(match[1])
+    const end = Number(match[2] ?? match[1])
+    if (start < 1 || end < start || end > rows.length)
+      return { action: 'invalid', changed: false, locked: false }
+    for (let index = start; index <= end; index += 1) indexes.add(index)
+  }
+  if (!indexes.size) return { action: 'invalid', changed: false, locked: false }
+  let locked = false
+  for (const index of indexes) {
+    const row = rows[index - 1]
+    if (row.locked) {
+      locked = true
+      continue
+    }
+    if (state.selectedCapabilityIds.has(row.capability.id))
+      state.selectedCapabilityIds.delete(row.capability.id)
+    else state.selectedCapabilityIds.add(row.capability.id)
+  }
+  return { action: 'changed', changed: true, locked }
+}
+
+export function finalizeFileViewerCapabilitySelection(state: FileViewerCapabilitySelectionState) {
+  const selected = state.catalog.capabilities
+    .filter((capability) => state.selectedCapabilityIds.has(capability.id))
+    .map((capability) => capability.id)
+  return {
+    formats: [...state.unknownFormats],
+    capabilities: [...selected, ...state.unknownCapabilities],
+  }
+}
+
+export async function promptFileViewerCapabilitySelection(input: {
+  catalog: FileViewerCliCatalog
+  profile: FileViewerProfile
+  locale: FileViewerCliLocale
+  formats?: readonly string[]
+  capabilities?: readonly string[]
+  question: (prompt: string) => Promise<string>
+  write: (output: string) => void
+}) {
+  const copy = selectionCopy[input.locale]
+  const state = createFileViewerCapabilitySelection(input)
+  const groups = (['formats', 'enhancements'] as const).filter(
+    (group) => listFileViewerCapabilitySelectionRows(state, group).length > 0
+  )
+  let groupIndex = 0
+  while (groupIndex < groups.length) {
+    const group = groups[groupIndex]
+    input.write(renderFileViewerSelectionGroup(state, group, input.locale))
+    const result = applyFileViewerSelectionCommand(state, group, await input.question(copy.prompt))
+    if (result.action === 'cancel') throw new Error(copy.cancelled)
+    if (result.action === 'back') {
+      if (groupIndex === 0) return null
+      groupIndex -= 1
+      continue
+    }
+    if (result.action === 'invalid') {
+      input.write(`  ${copy.invalid}\n`)
+      continue
+    }
+    if (result.action === 'changed') {
+      if (result.locked) input.write(`  ${copy.locked}\n`)
+      continue
+    }
+    groupIndex += 1
+  }
+  return finalizeFileViewerCapabilitySelection(state)
+}

--- a/packages/tools/cli/test/interactive-selection.test.mjs
+++ b/packages/tools/cli/test/interactive-selection.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+import {
+  applyFileViewerSelectionCommand,
+  createFileViewerCapabilitySelection,
+  finalizeFileViewerCapabilitySelection,
+  listFileViewerCapabilitySelectionRows,
+  promptFileViewerCapabilitySelection,
+  renderFileViewerSelectionGroup,
+} from '../dist/interactive-selection.js'
+
+const capability = (id, packageName, formats = [], options = {}) => ({
+  id,
+  packageName,
+  version: '3.0.0',
+  rendererIds: [id],
+  formats,
+  assets: {},
+  license: { spdx: 'Apache-2.0', policy: options.policy ?? 'permissive' },
+  weight: options.weight ?? 'light',
+  profiles: [],
+})
+
+const catalog = {
+  profiles: [
+    {
+      id: 'standard',
+      packageName: '@file-viewer/preset-standard',
+      version: '3.0.0',
+      capabilityPackages: ['@file-viewer/renderer-pdf'],
+    },
+  ],
+  capabilities: [
+    capability('pdf', '@file-viewer/renderer-pdf', ['pdf']),
+    capability('cad', '@file-viewer/renderer-cad', ['dwg', 'dxf', 'dwf'], { weight: 'heavy' }),
+    capability('archive', '@file-viewer/renderer-archive', ['zip', 'rar', '7z']),
+    capability('digital-signature', '@file-viewer/renderer-signature', [], {
+      weight: 'heavy',
+      policy: 'review-required',
+    }),
+  ],
+  legacyFull: { excludedFutureCapabilities: ['digital-signature'] },
+}
+
+test('preselects profile capabilities and keeps them locked', () => {
+  const state = createFileViewerCapabilitySelection({
+    catalog,
+    profile: 'standard',
+    formats: ['.dxf'],
+  })
+  const rows = listFileViewerCapabilitySelectionRows(state, 'formats')
+  assert.deepEqual(
+    rows.map(({ capability: item, selected, locked }) => [item.id, selected, locked]),
+    [
+      ['pdf', true, true],
+      ['cad', true, false],
+      ['archive', false, false],
+    ]
+  )
+  assert.match(renderFileViewerSelectionGroup(state, 'formats', 'en'), /\[✓\].*PDF.*\.pdf.*profile/)
+  assert.match(renderFileViewerSelectionGroup(state, 'formats', 'en'), /\[x\].*CAD.*\.dwg.*\.dxf/)
+})
+
+test('toggles numbers and ranges without disabling profile rows', () => {
+  const state = createFileViewerCapabilitySelection({ catalog, profile: 'standard' })
+  const result = applyFileViewerSelectionCommand(state, 'formats', '1-3')
+  assert.equal(result.action, 'changed')
+  assert.equal(result.locked, true)
+  assert.deepEqual(finalizeFileViewerCapabilitySelection(state), {
+    formats: [],
+    capabilities: ['cad', 'archive'],
+  })
+  assert.equal(applyFileViewerSelectionCommand(state, 'formats', '99').action, 'invalid')
+})
+
+test('walks format and extensionless capability pages with checkbox output', async () => {
+  const answers = ['2', '', '1', '']
+  let output = ''
+  const result = await promptFileViewerCapabilitySelection({
+    catalog,
+    profile: 'standard',
+    locale: 'zh-CN',
+    question: async () => answers.shift() ?? '',
+    write: (value) => {
+      output += value
+    },
+  })
+  assert.deepEqual(result, { formats: [], capabilities: ['cad', 'digital-signature'] })
+  assert.match(output, /文件格式族/)
+  assert.match(output, /无扩展名的可选增强能力/)
+  assert.match(output, /\[✓\].*PDF/)
+  assert.match(output, /\[x\].*CAD/)
+  assert.match(output, /需关注许可证/)
+})
+
+test('full profile locks the legacy matrix while leaving future capabilities optional', () => {
+  const state = createFileViewerCapabilitySelection({ catalog, profile: 'full' })
+  assert.deepEqual(
+    listFileViewerCapabilitySelectionRows(state, 'formats').map(({ capability: item, locked }) => [
+      item.id,
+      locked,
+    ]),
+    [
+      ['pdf', true],
+      ['cad', true],
+      ['archive', true],
+    ]
+  )
+  assert.equal(listFileViewerCapabilitySelectionRows(state, 'enhancements')[0].locked, false)
+})
+
+test('maps the frozen standard profile to preselected catalog rows', async () => {
+  const frozenCatalog = JSON.parse(
+    await readFile(new URL('../catalog/catalog.json', import.meta.url), 'utf8')
+  )
+  const state = createFileViewerCapabilitySelection({
+    catalog: frozenCatalog,
+    profile: 'standard',
+  })
+  const rows = listFileViewerCapabilitySelectionRows(state, 'formats')
+  const inherited = rows.filter((row) => row.locked)
+  assert.ok(rows.length > 0)
+  assert.ok(inherited.length > 0)
+  assert.ok(inherited.every((row) => row.selected))
+  assert.match(renderFileViewerSelectionGroup(state, 'formats', 'en'), /\[✓\]/)
+})

--- a/packages/tools/cli/test/quickstart-runtime.test.mjs
+++ b/packages/tools/cli/test/quickstart-runtime.test.mjs
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+import { scaffoldFileViewerQuickstart } from '../dist/index.js'
+
+const createRoot = async (t) => {
+  const root = await mkdtemp(join(tmpdir(), 'file-viewer-quickstart-runtime-'))
+  t.after(() => rm(root, { recursive: true, force: true }))
+  return root
+}
+
+test('generated Vite project declares and enforces its Node runtime contract', async (t) => {
+  const root = await createRoot(t)
+  await scaffoldFileViewerQuickstart(
+    root,
+    {
+      framework: 'web',
+      profile: 'standard',
+      packageManager: 'pnpm',
+      packageManagerVersion: '11.0.9',
+    },
+    { write: true }
+  )
+
+  const manifest = JSON.parse(await readFile(join(root, 'package.json'), 'utf8'))
+  assert.equal(manifest.engines.node, '^20.19.0 || >=22.12.0')
+  assert.equal(manifest.scripts.dev, 'node ./scripts/check-node.mjs && vite')
+  assert.equal(manifest.scripts.build, 'node ./scripts/check-node.mjs && vite build')
+
+  const guard = await readFile(join(root, 'scripts/check-node.mjs'), 'utf8')
+  assert.match(guard, /File Viewer quickstart uses Vite 8/)
+  assert.match(guard, /\^20\.19\.0 \|\| >=22\.12\.0/)
+  assert.match(guard, /remove node_modules, and reinstall dependencies/)
+})


### PR DESCRIPTION
## Summary

- Replace free-text format/capability entry with a checkbox-style capability selector that visibly preselects the selected profile, keeps inherited capabilities enabled, and supports number/range toggles, select-all, clear-extras, back, cancel, and confirmation.
- Harden generated Vite 8 projects with an explicit Node runtime contract and an actionable preflight guard instead of exposing low-level startup failures.
- Dispatch Web Component custom events from the element's owning DOM realm, with standards-compatible fallbacks for runtimes where the global `CustomEvent` constructor is unavailable.
- Add focused CLI/Web Component regression coverage, a full default-project `pnpm dev` smoke test, localized documentation, changelog entries, and visual evidence.

## Related issue

N/A: user-reported CLI regression; no linked GitHub issue.

## Change classification

- [x] User-visible UI or rendering change
- [ ] Non-visual change
- [ ] File-format or renderer behavior
- [ ] Public API, package, Worker, WASM, or deployment-path change

## Verification

| Check | Result |
| --- | --- |
| `pnpm --filter @file-viewer/cli exec tsc -b tsconfig.json --force` | Pass |
| Focused CLI suite: carrier commands, interactive selection, project adapters, quickstart runtime, URL security | Pass — 17/17 |
| `pnpm --filter @file-viewer/web build` | Pass — 2/2 CustomEvent compatibility tests |
| Full default flow: `file-viewer create` with Web/standard/pnpm, then `pnpm dev --host 127.0.0.1 --port 4173 --strictPort` | Pass — Vite served the page and actual module entry; no `CustomEvent is not defined` in the log |

## Sample / fixture evidence

- N/A: no file-format parser or renderer route changed; the regression is in CLI generation, startup compatibility, and interactive selection.

## Visual evidence

- Before: the wizard required users to type comma-separated extensions and capability names without showing the available matrix or current profile selection.
- After:

![Interactive capability selector](https://raw.githubusercontent.com/flyfish-dev/file-viewer/feature/cli-interactive-format-selection/docs/public/images/cli-capability-selector.svg)

## Risk and compatibility

- Affected packages/formats: `@file-viewer/cli`, `@file-viewer/web`, and newly generated Vite quickstarts; no parser or format output changes.
- Compatibility or migration risk: existing CLI flags, non-interactive usage, stored unknown tokens, and profile behavior remain supported. Newly generated Vite 8 projects explicitly require `^20.19.0 || >=22.12.0`; unsupported Node versions now fail early with upgrade/reinstall guidance.
- Rollback: revert the single feature commit.

## Checklist

- [x] I added or updated focused automated coverage, or explained why it is not needed.
- [x] I updated user-facing documentation or release notes when behavior or API changed, or marked them not applicable.
- [x] I verified offline/private-deployment paths when changing Worker, WASM, fonts, vendor assets, or URLs.
- [x] I did not commit secrets, customer files, private samples, generated caches, or unrelated changes.
