### PR TITLE
fix(release): allow package-specific manifest versions

### DIFF
--- a/.github/scripts/publish-release-assets.mjs
+++ b/.github/scripts/publish-release-assets.mjs
@@ -111,7 +111,7 @@ async function verifyAsset(entry) {
     throw new Error(`${name} repository.url must point to ${trustedRepositoryUrl}`)
   }
   if (packageJson.private === true) throw new Error(`${name} is private`)
-  if (version !== manifest.version) throw new Error(`${name} must use release ${manifest.version}`)
+  // The release tag groups the artifact set; each manifest record owns its package version.
   return Object.assign(record, {
     tarball,
     packageJson,

--- a/.github/scripts/publish-release-assets.test.mjs
+++ b/.github/scripts/publish-release-assets.test.mjs
@@ -10,7 +10,7 @@ import { captureCommand } from './npm-release-batch.mjs'
 const publisher = join(dirname(fileURLToPath(import.meta.url)), 'publish-release-assets.mjs')
 const repository = 'https://github.com/flyfish-dev/file-viewer'
 
-async function fixture(t, scenario = '') {
+async function fixture(t, scenario = '', extraPackages = []) {
   const root = await mkdtemp(join(tmpdir(), 'file-viewer-publish-test-'))
   t.after(() => rm(root, { recursive: true, force: true }))
   const bin = join(root, 'bin')
@@ -19,21 +19,22 @@ async function fixture(t, scenario = '') {
   await mkdir(assets)
   const entries = []
   const existing = {}
-  for (const [name, dependencies] of [
+  for (const [name, dependencies, version = '3.0.3'] of [
     ['full', { ui: '3.0.3' }],
     ['ui', { core: '3.0.3' }],
-    ['core', {}]
+    ['core', {}],
+    ...extraPackages
   ]) {
     const directory = join(root, name)
     await mkdir(join(directory, 'package'), { recursive: true })
     const pkg = {
       name,
-      version: '3.0.3',
+      version,
       dependencies,
       repository: { type: 'git', url: repository }
     }
     await writeFile(join(directory, 'package/package.json'), JSON.stringify(pkg))
-    const tarball = `${name}-3.0.3.tgz`
+    const tarball = `${name}-${version}.tgz`
     assert.equal(
       (await captureCommand('tar', ['-czf', join(assets, tarball), '-C', directory, 'package']))
         .status,
@@ -42,13 +43,13 @@ async function fixture(t, scenario = '') {
     const bytes = await readFile(join(assets, tarball))
     existing[name] = {
       name,
-      version: '3.0.3',
+      version,
       'dist.integrity': `sha512-${createHash('sha512').update(bytes).digest('base64')}`,
       'dist.tarball': `https://registry.npmjs.org/${name}/-/${tarball}`
     }
     entries.push({
       packageName: name,
-      version: '3.0.3',
+      version,
       tarball,
       sha256: createHash('sha256').update(bytes).digest('hex')
     })
@@ -121,6 +122,13 @@ test('publisher obeys dependency order and resumes without republishing exact by
   const report = JSON.parse(await readFile(join(f.assets, 'npm-publish-report.json'), 'utf8'))
   assert.equal(report.status, 'verified')
   assert(report.packages.every((r) => r.status === 'verified-existing'))
+})
+
+test('publisher accepts a manifest package version distinct from the GitHub release tag', async (t) => {
+  const f = await fixture(t, '', [['compat', {}, '0.2.6']])
+  const outcome = await f.run()
+  assert.equal(outcome.status, 0, outcome.stderr)
+  assert.deepEqual((await f.calls()).sort(), ['compat', 'core', 'full', 'ui'])
 })
 
 test('a later invalid tarball blocks all writes, not just its own layer', async (t) => {


### PR DESCRIPTION
## Summary

- Permit a compatibility package to retain its declared version when it differs from the GitHub Release tag.
- Keep tarball SHA-256, package identity, repository origin, and registry-integrity checks unchanged.
- Add a regression fixture for `compat@0.2.6` under release `v3.0.3`.

## Related issue

N/A: repairs the v3.0.3 trusted-publishing failure before the first package publish.

## Change classification

- [x] Non-visual change

## Verification

| Check | Result |
| --- | --- |
| `node --test .github/scripts/npm-release-batch.test.mjs .github/scripts/publish-release-assets.test.mjs` | Pass |
| `npm run verify:github-governance` | Pass |
| Frozen `v3.0.3` 88-package `--dry-run` | Pass |

## Sample / fixture evidence

- N/A: release publisher manifest and tarball fixture only.

## Visual evidence

- N/A: no rendered output changes; this only validates immutable release tarballs before publication.

## Risk and compatibility

- Affected packages/formats: GitHub OIDC release publisher only; no runtime or package payload changes.
- Compatibility or migration risk: supports manifest-declared compatibility versions such as `msdoc-viewer@0.2.6` without weakening tarball validation.
- Rollback: revert this workflow-source commit; no npm package or Release asset is changed by this PR.

## Checklist

- [x] I added focused automated coverage.
- [x] User-facing documentation and release notes are not applicable to this internal publisher validation fix.
- [x] Worker, WASM, font, vendor asset, and URL paths are not changed.
- [x] I did not commit secrets, customer files, private samples, generated caches, or unrelated changes.