### PR TITLE
fix(release): use reviewed publisher for recovery dispatches

### DIFF
--- a/.github/scripts/npm-publish-workflow.test.mjs
+++ b/.github/scripts/npm-publish-workflow.test.mjs
@@ -1,0 +1,15 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import test from 'node:test'
+
+const workflows = join(dirname(fileURLToPath(import.meta.url)), '..', 'workflows')
+
+test('manual npm publisher recovery checks out its reviewed workflow revision', async () => {
+  const workflow = await readFile(join(workflows, 'npm-publish.yml'), 'utf8')
+  assert.match(
+    workflow,
+    /ref: \$\{\{ github\.event_name == 'workflow_dispatch' && github\.sha \|\| github\.event\.release\.tag_name \}\}/
+  )
+})

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Check out release publisher
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.release.tag_name || inputs.release_tag }}
+          # A recovery dispatch needs the reviewed publisher revision; the tag can predate its fix.
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.release.tag_name }}
           persist-credentials: false
 
       - name: Set up Node.js


### PR DESCRIPTION
## Summary

- Keep published Release events pinned to their immutable tag.
- Make manual recovery dispatches check out the reviewed workflow revision instead of an older immutable tag.
- Add a regression test for the recovery checkout contract.

## Related issue

N/A: repairs the v3.0.3 trusted-publishing recovery path after its publisher validation fix.

## Change classification

- [x] Non-visual change

## Verification

| Check | Result |
| --- | --- |
| `node --test .github/scripts/npm-publish-workflow.test.mjs .github/scripts/npm-release-batch.test.mjs .github/scripts/publish-release-assets.test.mjs` | Pass |
| `npm run verify:github-governance` | Pass |
| Frozen `v3.0.3` 88-package `--dry-run` | Reused: publisher source and immutable assets are unchanged |

## Sample / fixture evidence

- N/A: workflow dispatch contract and repository tarball fixture only.

## Visual evidence

- N/A: no rendered output changes; this only selects the reviewed publisher for a recovery dispatch.

## Risk and compatibility

- Affected packages/formats: GitHub OIDC release workflow only; no runtime or package payload changes.
- Compatibility or migration risk: normal release events remain tag-pinned; recovery dispatches use the protected workflow revision that initiated them.
- Rollback: revert this workflow-source commit; no npm package or Release asset is changed by this PR.

## Checklist

- [x] I added focused automated coverage.
- [x] User-facing documentation and release notes are not applicable to this internal workflow recovery fix.
- [x] Worker, WASM, font, vendor asset, and URL paths are not changed.
- [x] I did not commit secrets, customer files, private samples, generated caches, or unrelated changes.