### PR TITLE
docs: align English CAD license notice

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -277,4 +277,12 @@ pnpm verify:browser-smoke
 
 Compatibility reports, deployment feedback, focused fixes and sanitized regression samples are welcome. Every bug report must include a public/sanitized sample, a public reproduction link, or a dated note that the private sample was sent to `admin@flyfish.dev`; screenshots do not replace the sample. Read [CONTRIBUTING.md](CONTRIBUTING.md) and [SECURITY.md](SECURITY.md) before opening an issue or pull request.
 
-Apache-2.0 licensed. Community links, Wiki and acknowledgements are available in the [documentation](https://doc.file-viewer.app/) and repository sidebar.
+## CAD License Notice
+
+The DWG/DWF/DWFX capability loads `@flyfish-dev/cad-viewer@0.8.2` and its `dwf-viewer@0.6.7` runtime dependency. Those CAD runtime components are **AGPL-3.0-only**. They are not covered by the Apache-2.0 license that applies to the rest of File Viewer source; using, redistributing, or modifying this CAD capability requires complying with AGPL-3.0.
+
+`dwf-viewer` is an internally authorized Flyfish product-line dependency. That authorization permits File Viewer to reference it internally; it does not grant external recipients a proprietary license or change the AGPL-3.0-only terms for this CAD capability.
+
+This release does not include the separately licensed commercial `dwg-viewer` product. Commercial DWG requirements may be directed to that product when appropriate, rather than represented as part of this AGPL capability.
+
+Except for the disclosed CAD runtime boundary above, File Viewer source is Apache-2.0 licensed. Community links, Wiki and acknowledgements are available in the [documentation](https://doc.file-viewer.app/) and repository sidebar.


### PR DESCRIPTION
## Summary

- Align the English README with the CAD/AGPL notice already published in README.md.
- Keep the internal DWF authorization and separate commercial DWG boundary explicit.
- No package, runtime, or Release-asset changes.

## Related issue

N/A: Documentation parity correction for the published 3.0.3 CAD license notice.

## Change classification

- [ ] User-visible UI or rendering change
- [x] Non-visual change
- [ ] File-format or renderer behavior
- [ ] Public API, package, Worker, WASM, or deployment-path change

## Verification

| Check | Result |
| --- | --- |
| `node scripts/verify-public-main.mjs --public-repo-dir /private/tmp/fv-public-postcheck-main` | Pass |

## Sample / fixture evidence

- N/A: Documentation-only license disclosure; no renderer or fixture changes.

## Visual evidence

- N/A: Non-visual documentation-only correction.

## Risk and compatibility

- Affected packages/formats: README.en.md only; no package or format behavior.
- Compatibility or migration risk: None; aligns terms already in README.md.
- Rollback: Revert this single documentation commit if disclosure text is superseded.

## Checklist

- [x] I added or updated focused automated coverage, or explained why it is not needed.
- [x] I updated user-facing documentation or release notes when behavior or API changed, or marked them not applicable.
- [x] I verified offline/private-deployment paths when changing Worker, WASM, fonts, vendor assets, or URLs.
- [x] I did not commit secrets, customer files, private samples, generated caches, or unrelated changes.